### PR TITLE
Import of a multiplatform workaround

### DIFF
--- a/source-api/build.gradle.kts
+++ b/source-api/build.gradle.kts
@@ -19,6 +19,10 @@ kotlin {
             dependencies {
                 implementation(project(":core"))
                 api(libs.preferencektx)
+
+                // Workaround for https://youtrack.jetbrains.com/issue/KT-57605
+                implementation(kotlinx.coroutines.android)
+                implementation(project.dependencies.platform(kotlinx.coroutines.bom))
             }
         }
     }


### PR DESCRIPTION
Sometimes it dosen't recognise the commonMain in source-api. This is a workaround so there are no problems with further coding. Is taken from a Tachiyomi commit