### PR TITLE
feat(player): add option for chapter seeking using media controls

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
@@ -194,6 +194,7 @@ object SettingsPlayerScreen : SearchableSettings {
         val defaultSkipIntroLength by playerPreferences.defaultIntroLength().stateIn(scope).collectAsState()
         val skipLengthPreference = playerPreferences.skipLengthPreference()
         val playerSmoothSeek = playerPreferences.playerSmoothSeek()
+        val mediaChapterSeek = playerPreferences.mediaChapterSeek()
 
         var showDialog by rememberSaveable { mutableStateOf(false) }
         if (showDialog) {
@@ -243,6 +244,10 @@ object SettingsPlayerScreen : SearchableSettings {
                     pref = playerSmoothSeek,
                     title = stringResource(R.string.pref_player_smooth_seek),
                     subtitle = stringResource(R.string.pref_player_smooth_seek_summary),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    pref = mediaChapterSeek,
+                    title = stringResource(R.string.pref_media_control_chapter_seeking),
                 ),
                 Preference.PreferenceItem.InfoPreference(
                     title = stringResource(R.string.pref_category_player_aniskip_info),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -485,7 +485,7 @@ class PlayerActivity : BaseActivity() {
 
                     override fun onSkipToPrevious() {
                         if (playerPreferences.mediaChapterSeek().get()) {
-                            if (player.loadChapters() != emptyList<Chapter>()) {
+                            if (player.loadChapters().isNotEmpty()) {
                                 MPVLib.command(arrayOf("add", "chapter", "-1"))
                             }
                         } else {
@@ -495,7 +495,7 @@ class PlayerActivity : BaseActivity() {
 
                     override fun onSkipToNext() {
                         if (playerPreferences.mediaChapterSeek().get()) {
-                            if (player.loadChapters() != emptyList<Chapter>()) {
+                            if (player.loadChapters().isNotEmpty()) {
                                 MPVLib.command(arrayOf("add", "chapter", "1"))
                             }
                         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -484,11 +484,23 @@ class PlayerActivity : BaseActivity() {
                     }
 
                     override fun onSkipToPrevious() {
-                        changeEpisode(viewModel.getAdjacentEpisodeId(previous = true))
+                        if (playerPreferences.mediaChapterSeek().get()) {
+                            if (player.loadChapters() != emptyList<Chapter>()) {
+                                MPVLib.command(arrayOf("add", "chapter", "-1"))
+                            }
+                        } else {
+                            changeEpisode(viewModel.getAdjacentEpisodeId(previous = true))
+                        }
                     }
 
                     override fun onSkipToNext() {
-                        changeEpisode(viewModel.getAdjacentEpisodeId(previous = false))
+                        if (playerPreferences.mediaChapterSeek().get()) {
+                            if (player.loadChapters() != emptyList<Chapter>()) {
+                                MPVLib.command(arrayOf("add", "chapter", "1"))
+                            }
+                        } else {
+                            changeEpisode(viewModel.getAdjacentEpisodeId(previous = false))
+                        }
                     }
                 },
             )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
@@ -43,6 +43,8 @@ class PlayerPreferences(
 
     fun playerSmoothSeek() = preferenceStore.getBoolean("pref_player_smooth_seek", false)
 
+    fun mediaChapterSeek() = preferenceStore.getBoolean("pref_media_control_chapter_seeking", false)
+
     fun playerViewMode() = preferenceStore.getInt("pref_player_view_mode", AspectState.FIT.index)
 
     fun playerFullscreen() = preferenceStore.getBoolean("player_fullscreen", true)

--- a/app/src/main/res/layout/player_controls.xml
+++ b/app/src/main/res/layout/player_controls.xml
@@ -63,7 +63,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="10dp"
-                android:layout_marginTop="10dp"
+                android:layout_marginTop="6dp"
                 android:textColor="?attr/colorOnPrimarySurface"
                 android:textSize="14sp"
                 android:textStyle="bold"

--- a/app/src/main/res/layout/player_controls.xml
+++ b/app/src/main/res/layout/player_controls.xml
@@ -63,7 +63,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="10dp"
-                android:layout_marginTop="6dp"
+                android:layout_marginTop="16dp"
                 android:textColor="?attr/colorOnPrimarySurface"
                 android:textSize="14sp"
                 android:textStyle="bold"

--- a/i18n/src/main/res/values/strings-aniyomi.xml
+++ b/i18n/src/main/res/values/strings-aniyomi.xml
@@ -106,6 +106,7 @@
     <string name="pref_skip_5" translatable="false">5s</string>
     <string name="pref_skip_3" translatable="false">3s</string>
     <string name="pref_skip_disable">Disable</string>
+    <string name="pref_media_control_chapter_seeking">Use media controls for chapter seeking</string>
     <string name="pref_player_smooth_seek">Enable precise seeking</string>
     <string name="pref_player_smooth_seek_summary">When enabled, seeking will not focus on keyframes, leading to slower but precise seeking</string>
     <string name="pref_player_fullscreen">Show content in display cutout</string>


### PR DESCRIPTION
Adds an option to seek through chapters with media controls. If the video provides a separate chapter for opening for example, skipping opening with media controls will be faster, more reliable, and more convenient compared to existing methods.