### PR TITLE
feat(player): add intro skip for media controls

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
@@ -248,6 +248,7 @@ object SettingsPlayerScreen : SearchableSettings {
                 Preference.PreferenceItem.SwitchPreference(
                     pref = mediaChapterSeek,
                     title = stringResource(R.string.pref_media_control_chapter_seeking),
+                    subtitle = stringResource(R.string.pref_media_control_chapter_seeking_summary),
                 ),
                 Preference.PreferenceItem.InfoPreference(
                     title = stringResource(R.string.pref_category_player_aniskip_info),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -497,6 +497,9 @@ class PlayerActivity : BaseActivity() {
                         if (playerPreferences.mediaChapterSeek().get()) {
                             if (player.loadChapters().isNotEmpty()) {
                                 MPVLib.command(arrayOf("add", "chapter", "1"))
+                            } else {
+                                 doubleTapSeek(viewModel.getAnimeSkipIntroLength(), isDoubleTap = false)
+                                 playerControls.resetControlsFade()
                             }
                         } else {
                             changeEpisode(viewModel.getAdjacentEpisodeId(previous = false))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -487,7 +487,7 @@ class PlayerActivity : BaseActivity() {
                         if (playerPreferences.mediaChapterSeek().get()) {
                             if (player.loadChapters().isNotEmpty()) {
                                 MPVLib.command(arrayOf("add", "chapter", "-1"))
-                                skipAnimation("Previous chapter", isForward = false)
+                                skipAnimation(getString(R.string.go_to_previous_chapter), isForward = false)
                             }
                         } else {
                             changeEpisode(viewModel.getAdjacentEpisodeId(previous = true))
@@ -498,10 +498,10 @@ class PlayerActivity : BaseActivity() {
                         if (playerPreferences.mediaChapterSeek().get()) {
                             if (player.loadChapters().isNotEmpty()) {
                                 MPVLib.command(arrayOf("add", "chapter", "1"))
-                                skipAnimation("Next chapter", isForward = true)
+                                skipAnimation(getString(R.string.go_to_next_chapter), isForward = true)
                             } else {
                                 MPVLib.command(arrayOf("seek", viewModel.getAnimeSkipIntroLength().toString(), "relative+exact"))
-                                skipAnimation("Skipped opening", isForward = true)
+                                skipAnimation(getString(R.string.go_to_after_opening), isForward = true)
                             }
                         } else {
                             changeEpisode(viewModel.getAdjacentEpisodeId(previous = false))

--- a/i18n/src/main/res/values/strings-aniyomi.xml
+++ b/i18n/src/main/res/values/strings-aniyomi.xml
@@ -108,6 +108,9 @@
     <string name="pref_skip_disable">Disable</string>
     <string name="pref_media_control_chapter_seeking">Seek chapters with media controls</string>
     <string name="pref_media_control_chapter_seeking_summary">When enabled, using next will invoke the skip intro button if no chapters are found</string>
+    <string name="go_to_next_chapter">Next chapter</string>
+    <string name="go_to_previous_chapter">Previous chapter</string>
+    <string name="go_to_after_opening">Skipped opening</string>
     <string name="pref_player_smooth_seek">Enable precise seeking</string>
     <string name="pref_player_smooth_seek_summary">When enabled, seeking will not focus on keyframes, leading to slower but precise seeking</string>
     <string name="pref_player_fullscreen">Show content in display cutout</string>

--- a/i18n/src/main/res/values/strings-aniyomi.xml
+++ b/i18n/src/main/res/values/strings-aniyomi.xml
@@ -106,7 +106,8 @@
     <string name="pref_skip_5" translatable="false">5s</string>
     <string name="pref_skip_3" translatable="false">3s</string>
     <string name="pref_skip_disable">Disable</string>
-    <string name="pref_media_control_chapter_seeking">Use media controls for chapter seeking</string>
+    <string name="pref_media_control_chapter_seeking">Seek chapters with media controls</string>
+    <string name="pref_media_control_chapter_seeking_summary">When enabled, using next will invoke the skip intro button if no chapters are found</string>
     <string name="pref_player_smooth_seek">Enable precise seeking</string>
     <string name="pref_player_smooth_seek_summary">When enabled, seeking will not focus on keyframes, leading to slower but precise seeking</string>
     <string name="pref_player_fullscreen">Show content in display cutout</string>


### PR DESCRIPTION
When there's no chapters available, and "Seek chapters with media controls" is enabled, the skip intro button will be invoked. Slight rephrase to prevent ugly text overflowing.

Also adds animations for actions taken using next/previous with media controls