### PR TITLE
feat(downloader): restrict parallel downloads to unmetered sources

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -69,8 +69,9 @@ object SettingsDownloadScreen : SearchableSettings {
             Preference.PreferenceItem.ListPreference(
                 pref = downloadPreferences.numberOfDownloads(),
                 title = stringResource(R.string.pref_download_slots),
-                entries = listOf(1, 2, 3).associateWith { it.toString() },
+                entries = (1..5).associateWith { it.toString() },
             ),
+            Preference.PreferenceItem.InfoPreference(stringResource(R.string.download_slots_info)),
             getDeleteChaptersGroup(
                 downloadPreferences = downloadPreferences,
                 categories = allCategories,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
@@ -216,10 +216,14 @@ class AnimeDownloader(
                                 .subscribeOn(Schedulers.io())
                                 .observeOn(AndroidSchedulers.mainThread())
                         },
-                        downloadPreferences.numberOfDownloads().get(),
+                        if (sourceManager.get(bySource.key.id) is UnmeteredSource) {
+                            downloadPreferences.numberOfDownloads().get()
+                        } else {
+                            1
+                        },
                     )
                 },
-                3,
+                5,
             )
             .subscribe(
                 { completedDownload ->

--- a/i18n/src/main/res/values/strings-aniyomi.xml
+++ b/i18n/src/main/res/values/strings-aniyomi.xml
@@ -339,4 +339,5 @@
     <string name="resmush">resmush.it</string>
     <string name="bandwidth_data_saver_server">Bandwidth Hero Proxy Server</string>
     <string name="data_saver_server_summary">Put Bandwidth Hero Proxy server url here</string>
+    <string name="download_slots_info">Will only download concurrently from self-hosted or unmetered sources</string>
 </resources>

--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -448,7 +448,6 @@
     <string name="split_tall_images">Split tall images</string>
     <string name="split_tall_images_summary">Improves reader performance</string>
     <string name="pref_download_slots">Maximum downloads</string>
-    <string name="download_slots_info">Will only download in parallel from self-hosted sources</string>
 
     <!-- Tracking section -->
     <string name="tracking_guide">Tracking guide</string>

--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -448,6 +448,7 @@
     <string name="split_tall_images">Split tall images</string>
     <string name="split_tall_images_summary">Improves reader performance</string>
     <string name="pref_download_slots">Maximum downloads</string>
+    <string name="download_slots_info">Will only download in parallel from self-hosted sources</string>
 
     <!-- Tracking section -->
     <string name="tracking_guide">Tracking guide</string>


### PR DESCRIPTION
Also increases the number of parallel downloads to 5.

The reason for this change is to mitigate traffic for sources that self-host in some way or another. While the number of sources that self-host isn't crazy high, I believe it's high enough to justify this change.