### PR TITLE
feat(player): add Web Video Caster to external player preference

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
@@ -34,6 +34,7 @@ import eu.kanade.tachiyomi.ui.player.MX_PLAYER_FREE
 import eu.kanade.tachiyomi.ui.player.MX_PLAYER_PRO
 import eu.kanade.tachiyomi.ui.player.NEXT_PLAYER
 import eu.kanade.tachiyomi.ui.player.VLC_PLAYER
+import eu.kanade.tachiyomi.ui.player.WEB_VIDEO_CASTER
 import eu.kanade.tachiyomi.ui.player.X_PLAYER
 import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
 import tachiyomi.presentation.core.components.WheelTextPicker
@@ -395,4 +396,5 @@ val externalPlayers = listOf(
     JUST_PLAYER,
     NEXT_PLAYER,
     X_PLAYER,
+    WEB_VIDEO_CASTER,
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
@@ -24,6 +24,7 @@ import eu.kanade.tachiyomi.data.track.AnimeTrackService
 import eu.kanade.tachiyomi.data.track.TrackManager
 import eu.kanade.tachiyomi.ui.player.loader.EpisodeLoader
 import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
+import eu.kanade.tachiyomi.util.system.LocaleHelper
 import eu.kanade.tachiyomi.util.system.isOnline
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -180,7 +181,12 @@ class ExternalIntents {
                 headers.putString(it.first, it.second)
             }
 
-            video.subtitleTracks.firstOrNull()?.let {
+            val localLangName = LocaleHelper.getSimpleLocaleDisplayName()
+            video.subtitleTracks.firstOrNull {
+                it.lang.contains(localLangName)
+            }?.let {
+                putExtra("subtitle", it.url)
+            } ?: video.subtitleTracks.firstOrNull()?.let {
                 putExtra("subtitle", it.url)
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import android.os.Bundle
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import eu.kanade.core.util.asFlow
@@ -88,7 +89,7 @@ class ExternalIntents {
                 addVideoHeaders(false, video, this)
             }
         } else {
-            standardIntentForPackage(pkgName, context, videoUrl, video)
+            getIntentForPackage(pkgName, context, videoUrl, video)
         }
     }
 
@@ -151,6 +152,41 @@ class ExternalIntents {
      */
     private suspend fun makeErrorToast(context: Context, e: Exception?) {
         withUIContext { context.toast(e?.message ?: "Cannot open episode") }
+    }
+
+    /**
+     * Returns the [Intent] with added data to send to the given external player.
+     *
+     * @param pkgName the name of the package to send the [Intent] to.
+     * @param context the application context.
+     * @param uri the path data of the video.
+     * @param video the video being sent to the external player.
+     */
+    private fun getIntentForPackage(pkgName: String, context: Context, uri: Uri, video: Video): Intent {
+        return when (pkgName) {
+            WEB_VIDEO_CASTER -> webVideoCasterIntent(pkgName, context, uri, video)
+            else -> standardIntentForPackage(pkgName, context, uri, video)
+        }
+    }
+
+    private fun webVideoCasterIntent(pkgName: String, context: Context, uri: Uri, video: Video): Intent {
+        return Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "video/*")
+            if (isPackageInstalled(pkgName, context.packageManager)) setPackage(WEB_VIDEO_CASTER)
+            addExtrasAndFlags(true, this)
+
+            val headers = Bundle()
+            video.headers?.forEach {
+                headers.putString(it.first, it.second)
+            }
+
+            video.subtitleTracks.firstOrNull()?.let {
+                putExtra("subtitle", it.url)
+            }
+
+            putExtra("android.media.intent.extra.HTTP_HEADERS", headers)
+            putExtra("secure_uri", true)
+        }
     }
 
     /**
@@ -507,3 +543,4 @@ const val MPV_REMOTE = "com.husudosu.mpvremote"
 const val JUST_PLAYER = "com.brouken.player"
 const val NEXT_PLAYER = "dev.anilbeesetti.nextplayer"
 const val X_PLAYER = "video.player.videoplayer"
+const val WEB_VIDEO_CASTER = "com.instantbits.cast.webvideo"


### PR DESCRIPTION
Adds Web Video Caster to the external player preference. Since not all external players uses the same Intents, `getIntentForPackage` can be used to customize the intent for specific players.