### PR TITLE
Fix crash for external players + add subs

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.ui.main
 
 import android.animation.ValueAnimator
 import android.app.Activity
+import android.app.Application
 import android.app.SearchManager
 import android.app.assist.AssistContent
 import android.content.Context
@@ -108,6 +109,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import logcat.LogPriority
+import tachiyomi.core.util.lang.withUIContext
 import tachiyomi.core.util.system.logcat
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.presentation.core.components.material.Scaffold
@@ -523,7 +525,14 @@ class MainActivity : BaseActivity() {
 
         suspend fun startPlayerActivity(context: Context, animeId: Long, episodeId: Long, extPlayer: Boolean, video: Video? = null) {
             if (extPlayer) {
-                externalPlayerResult?.launch(ExternalIntents.newIntent(context, animeId, episodeId, video)) ?: return
+                val intent = try {
+                    ExternalIntents.newIntent(context, animeId, episodeId, video)
+                } catch (e: Exception) {
+                    logcat(LogPriority.ERROR, e)
+                    withUIContext { Injekt.get<Application>().toast(e.message) }
+                    return
+                }
+                externalPlayerResult?.launch(intent) ?: return
             } else {
                 context.startActivity(PlayerActivity.newIntent(context, animeId, episodeId))
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
@@ -221,26 +221,20 @@ class ExternalIntents {
 
             // Add support for Subtitles to external players
 
-            /*
-            val externalSubs = source.getExternalSubtitleStreams()
-            val enabledSubUrl = when {
-                source.selectedSubtitleStream != null -> {
-                    externalSubs.find { stream -> stream.index == source.selectedSubtitleStream?.index }?.let { sub ->
-                        apiClient.createUrl(sub.deliveryUrl)
-                    }
-                }
-                else -> null
+            val localLangName = LocaleHelper.getSimpleLocaleDisplayName()
+            val langIndex = video.subtitleTracks.indexOfFirst {
+                it.lang.contains(localLangName)
             }
+            val requestedLanguage = if (langIndex == -1) 0 else langIndex
+            val requestedUrl = video.subtitleTracks.getOrNull(requestedLanguage)?.url
 
-            // MX Player API / MPV
-            putExtra("subs", externalSubs.map { stream -> Uri.parse(apiClient.createUrl(stream.deliveryUrl)) }.toTypedArray())
-            putExtra("subs.name", externalSubs.map(ExternalSubtitleStream::displayTitle).toTypedArray())
-            putExtra("subs.filename", externalSubs.map(ExternalSubtitleStream::language).toTypedArray())
-            putExtra("subs.enable", enabledSubUrl?.let { url -> arrayOf(Uri.parse(url)) } ?: emptyArray())
+            // Just, Next, MX Player, mpv
+            putExtra("subs", video.subtitleTracks.map { Uri.parse(it.url) }.toTypedArray())
+            putExtra("subs.name", video.subtitleTracks.map { it.lang }.toTypedArray())
+            putExtra("subs.enable", requestedUrl?.let { arrayOf(Uri.parse(it)) } ?: emptyArray())
 
-            // VLC
-            if (enabledSubUrl != null) putExtra("subtitles_location", enabledSubUrl)
-             */
+            // VLC - seems to only work for local sub files
+            requestedUrl?.let { putExtra("subtitles_location", it) }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import logcat.LogPriority
 import tachiyomi.core.util.lang.launchIO
 import tachiyomi.core.util.lang.withIOContext
@@ -77,7 +78,9 @@ class ExternalIntents {
         source = sourceManager.get(anime.source) ?: return null
         episode = getEpisodeByAnimeId.await(anime.id).find { it.id == episodeId } ?: return null
 
-        val video = chosenVideo ?: EpisodeLoader.getLinks(episode, anime, source).asFlow().first()[0]
+        val video = chosenVideo
+            ?: EpisodeLoader.getLinks(episode, anime, source).asFlow().first().firstOrNull()
+            ?: throw Exception("Video list is empty")
 
         val videoUrl = getVideoUrl(context, video) ?: return null
 


### PR DESCRIPTION
Fixes crash when external player is called on an empty video list, or if the extension throws an exception. Adds some subtitles to external players that supports it.