### PR TITLE
feat(player): Add support for editing input.conf (closes #1163)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/AdvancedPlayerSettingsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/AdvancedPlayerSettingsScreen.kt
@@ -20,6 +20,7 @@ object AdvancedPlayerSettingsScreen : SearchableSettings {
         val playerPreferences = remember { Injekt.get<PlayerPreferences>() }
         val context = LocalContext.current
         val mpvConf = playerPreferences.mpvConf()
+        val mpvInput = playerPreferences.mpvInput()
         val scope = rememberCoroutineScope()
 
         return listOf(
@@ -33,6 +34,16 @@ object AdvancedPlayerSettingsScreen : SearchableSettings {
                         postfix = if (mpvConf.asState(scope).value.lines().size > 2) "\n..." else "",
                     ),
 
+            ),
+            Preference.PreferenceItem.MultiLineEditTextPreference(
+                pref = mpvInput,
+                title = context.getString(R.string.pref_mpv_input),
+                subtitle = mpvInput.asState(scope).value
+                    .lines().take(2)
+                    .joinToString(
+                        separator = "\n",
+                        postfix = if (mpvInput.asState(scope).value.lines().size > 2) "\n..." else "",
+                    ),
             ),
             Preference.PreferenceItem.ListPreference(
                 title = context.getString(R.string.pref_debanding_title),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
@@ -31,6 +31,8 @@ class PlayerPreferences(
 
     fun mpvConf() = preferenceStore.getString("pref_mpv_conf", "")
 
+    fun mpvInput() = preferenceStore.getString("pref_mpv_input", "")
+
     fun defaultPlayerOrientationType() = preferenceStore.getInt("pref_default_player_orientation_type_key", 10)
 
     fun adjustOrientationVideoDimensions() = preferenceStore.getBoolean("pref_adjust_orientation_video_dimensions", true)

--- a/i18n/src/main/res/values/strings-aniyomi.xml
+++ b/i18n/src/main/res/values/strings-aniyomi.xml
@@ -128,6 +128,7 @@
     <string name="pref_remember_volume">Remember and switch to the last used volume</string>
     <!-- Needs better English -->
     <string name="pref_mpv_conf">Edit MPV configuration file for further player settings</string>
+    <string name="pref_mpv_input">Edit MPV input file for keyboard mapping configuration</string>
     <string name="pref_category_external_player">External player</string>
     <string name="pref_always_use_external_player">Always use external player</string>
     <string name="pref_external_player_preference">External player preference</string>


### PR DESCRIPTION
Added the option to modify input.conf to allow users to assign different keyboard buttons to different player functions for mpv
tested this feature on waydroid and my phone with a keyboard attached with a usb-a to usb-c adapter which worked fine for the most part