### PR TITLE
feat(player): don't bring up screenshotsheet if player is locked

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/viewer/GestureHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/viewer/GestureHandler.kt
@@ -113,6 +113,7 @@ class GestureHandler(
     }
 
     override fun onLongPress(e: MotionEvent) {
+        if (SeekState.mode == SeekState.LOCKED) { playerControls.toggleControls(); return }
         activity.openScreenshotSheet()
     }
 }


### PR DESCRIPTION
If the player is locked, it shouldn't bring up the screenshotsheet on a long press