### PR TITLE
fix(storage-viewer): don't show hidden categories in all view

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/storage/CumulativeStorage.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/storage/CumulativeStorage.kt
@@ -31,15 +31,14 @@ fun CumulativeStorage(
             Canvas(
                 modifier = Modifier.aspectRatio(1f),
                 onDraw = {
+                    // don't bother drawing if there's no data
+                    if (totalSize == 0f) return@Canvas
+
                     val totalAngle = 180f
                     var currentAngle = 0f
                     rotate(180f) {
                         for (item in items) {
-                            val itemAngle = if (totalSize > 0f) {
-                                (item.size / totalSize) * totalAngle
-                            } else {
-                                0f
-                            }
+                            val itemAngle = (item.size / totalSize) * totalAngle
                             drawArc(
                                 color = item.color,
                                 startAngle = currentAngle,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/storage/CommonStorageScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/storage/CommonStorageScreenModel.kt
@@ -3,7 +3,6 @@ package eu.kanade.tachiyomi.ui.storage
 import androidx.compose.ui.graphics.Color
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.coroutineScope
-import eu.kanade.core.util.fastDistinctBy
 import eu.kanade.presentation.more.storage.StorageItem
 import eu.kanade.presentation.more.storage.StorageScreenState
 import kotlinx.coroutines.flow.Flow
@@ -15,58 +14,87 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import tachiyomi.core.util.lang.launchIO
 import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.library.service.LibraryPreferences
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import kotlin.random.Random
 
 abstract class CommonStorageScreenModel<T>(
     private val downloadCacheChanges: SharedFlow<Unit>,
     private val downloadCacheIsInitializing: StateFlow<Boolean>,
     private val libraries: Flow<List<T>>,
-    private val categories: Flow<List<Category>>,
+    private val categories: (Boolean) -> Flow<List<Category>>,
     private val getDownloadSize: T.() -> Long,
     private val getDownloadCount: T.() -> Int,
     private val getId: T.() -> Long,
     private val getCategoryId: T.() -> Long,
     private val getTitle: T.() -> String,
     private val getThumbnail: T.() -> String?,
+    private val libraryPreferences: LibraryPreferences = Injekt.get(),
 ) : StateScreenModel<StorageScreenState>(StorageScreenState.Loading) {
 
     private val selectedCategory = MutableStateFlow(AllCategory)
 
     init {
         coroutineScope.launchIO {
+            val hideHiddenCategories = libraryPreferences.hideHiddenCategoriesSettings().get()
+
             combine(
                 flow = downloadCacheChanges,
                 flow2 = downloadCacheIsInitializing,
                 flow3 = libraries,
-                flow4 = categories,
+                flow4 = categories(hideHiddenCategories),
                 flow5 = selectedCategory,
                 transform = { _, _, libraries, categories, selectedCategory ->
-                    val distinctLibraries = libraries.fastDistinctBy {
-                        it.getId()
-                    }.filter {
-                        selectedCategory == AllCategory || it.getCategoryId() == selectedCategory.id
-                    }
-
+                    // initialize the screen with an empty state
                     mutableState.update {
                         StorageScreenState.Success(
                             selectedCategory = selectedCategory,
                             categories = listOf(AllCategory, *categories.toTypedArray()),
-                            items = distinctLibraries.map {
-                                val random = Random(it.getId())
-                                StorageItem(
-                                    id = it.getId(),
-                                    title = it.getTitle(),
-                                    size = it.getDownloadSize(),
-                                    thumbnail = it.getThumbnail(),
-                                    entriesCount = it.getDownloadCount(),
-                                    color = Color(
-                                        random.nextInt(255),
-                                        random.nextInt(255),
-                                        random.nextInt(255),
-                                    ),
-                                )
-                            }.sortedByDescending { it.size },
+                            items = emptyList(),
                         )
+                    }
+
+                    val distinctLibraries = libraries.distinctBy {
+                        it.getId()
+                    }.filter { item ->
+                        val categoryId = item.getCategoryId()
+                        when {
+                            // if all is selected, we want to make sure to include all entries
+                            // from only visible categories
+                            selectedCategory == AllCategory -> categories.find {
+                                it.id == categoryId
+                            } != null
+
+                            // else include only entries from the selected category
+                            else -> categoryId == selectedCategory.id
+                        }
+                    }
+
+                    distinctLibraries.forEach { library ->
+                        val random = Random(library.getId())
+                        val item = StorageItem(
+                            id = library.getId(),
+                            title = library.getTitle(),
+                            size = library.getDownloadSize(),
+                            thumbnail = library.getThumbnail(),
+                            entriesCount = library.getDownloadCount(),
+                            color = Color(
+                                random.nextInt(255),
+                                random.nextInt(255),
+                                random.nextInt(255),
+                            ),
+                        )
+
+                        mutableState.update { state ->
+                            when (state) {
+                                is StorageScreenState.Success -> state.copy(
+                                    items = (state.items + item).sortedByDescending { it.size },
+                                )
+
+                                else -> state
+                            }
+                        }
                     }
                 },
             ).collectLatest {}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/storage/anime/AnimeStorageScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/storage/anime/AnimeStorageScreenModel.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.data.download.anime.AnimeDownloadCache
 import eu.kanade.tachiyomi.data.download.anime.AnimeDownloadManager
 import eu.kanade.tachiyomi.ui.storage.CommonStorageScreenModel
 import tachiyomi.core.util.lang.launchNonCancellable
+import tachiyomi.domain.category.anime.interactor.GetAnimeCategories
 import tachiyomi.domain.category.anime.interactor.GetVisibleAnimeCategories
 import tachiyomi.domain.entries.anime.interactor.GetLibraryAnime
 import tachiyomi.domain.library.anime.LibraryAnime
@@ -15,6 +16,7 @@ import uy.kohesive.injekt.api.get
 class AnimeStorageScreenModel(
     downloadCache: AnimeDownloadCache = Injekt.get(),
     private val getLibraries: GetLibraryAnime = Injekt.get(),
+    getCategories: GetAnimeCategories = Injekt.get(),
     getVisibleCategories: GetVisibleAnimeCategories = Injekt.get(),
     private val downloadManager: AnimeDownloadManager = Injekt.get(),
     private val sourceManager: AnimeSourceManager = Injekt.get(),
@@ -22,7 +24,13 @@ class AnimeStorageScreenModel(
     downloadCacheChanges = downloadCache.changes,
     downloadCacheIsInitializing = downloadCache.isInitializing,
     libraries = getLibraries.subscribe(),
-    categories = getVisibleCategories.subscribe(),
+    categories = { hideHiddenCategories ->
+        if (hideHiddenCategories) {
+            getVisibleCategories.subscribe()
+        } else {
+            getCategories.subscribe()
+        }
+    },
     getDownloadSize = { downloadManager.getDownloadSize(anime) },
     getDownloadCount = { downloadManager.getDownloadCount(anime) },
     getId = { id },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/storage/manga/MangaStorageScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/storage/manga/MangaStorageScreenModel.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.data.download.manga.MangaDownloadCache
 import eu.kanade.tachiyomi.data.download.manga.MangaDownloadManager
 import eu.kanade.tachiyomi.ui.storage.CommonStorageScreenModel
 import tachiyomi.core.util.lang.launchNonCancellable
+import tachiyomi.domain.category.manga.interactor.GetMangaCategories
 import tachiyomi.domain.category.manga.interactor.GetVisibleMangaCategories
 import tachiyomi.domain.entries.manga.interactor.GetLibraryManga
 import tachiyomi.domain.library.manga.LibraryManga
@@ -15,6 +16,7 @@ import uy.kohesive.injekt.api.get
 class MangaStorageScreenModel(
     downloadCache: MangaDownloadCache = Injekt.get(),
     private val getLibraries: GetLibraryManga = Injekt.get(),
+    getCategories: GetMangaCategories = Injekt.get(),
     getVisibleCategories: GetVisibleMangaCategories = Injekt.get(),
     private val downloadManager: MangaDownloadManager = Injekt.get(),
     private val sourceManager: MangaSourceManager = Injekt.get(),
@@ -22,7 +24,13 @@ class MangaStorageScreenModel(
     downloadCacheChanges = downloadCache.changes,
     downloadCacheIsInitializing = downloadCache.isInitializing,
     libraries = getLibraries.subscribe(),
-    categories = getVisibleCategories.subscribe(),
+    categories = { hideHiddenCategories ->
+        if (hideHiddenCategories) {
+            getVisibleCategories.subscribe()
+        } else {
+            getCategories.subscribe()
+        }
+    },
     getDownloadSize = { downloadManager.getDownloadSize(manga) },
     getDownloadCount = { downloadManager.getDownloadCount(manga) },
     getId = { id },

--- a/i18n/src/main/res/values/strings-aniyomi.xml
+++ b/i18n/src/main/res/values/strings-aniyomi.xml
@@ -324,7 +324,7 @@
     <string name="pref_episode_swipe_end">Swipe to right action</string>
     <string name="pref_episode_swipe_start">Swipe to left action</string>
 
-    <string name="pref_category_hide_hidden">Hide hidden categories from categories screen</string>
+    <string name="pref_category_hide_hidden">Hide hidden categories from categories and storage screen</string>
 
 
     <!-- Subtitle settings -->


### PR DESCRIPTION
closes #1191 

Hidden categories are controlled in the storage settings by the hidden category toggle.

![image](https://github.com/aniyomiorg/aniyomi/assets/42023982/82f6fe90-f0ef-431a-bcdd-651a63ca8172)