### PR TITLE
refactor: Make ordering of items consistent

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -265,19 +265,6 @@ object SettingsDownloadScreen : SearchableSettings {
             title = stringResource(MR.strings.download_ahead),
             preferenceItems = persistentListOf(
                 Preference.PreferenceItem.ListPreference(
-                    pref = downloadPreferences.autoDownloadWhileReading(),
-                    title = stringResource(MR.strings.auto_download_while_reading),
-                    entries = listOf(0, 2, 3, 5, 10)
-                        .associateWith {
-                            if (it == 0) {
-                                stringResource(MR.strings.disabled)
-                            } else {
-                                pluralStringResource(MR.plurals.next_unread_chapters, count = it, it)
-                            }
-                        }
-                        .toImmutableMap(),
-                ),
-                Preference.PreferenceItem.ListPreference(
                     pref = downloadPreferences.autoDownloadWhileWatching(),
                     title = stringResource(MR.strings.auto_download_while_watching),
                     entries = listOf(0, 2, 3, 5, 10)
@@ -286,6 +273,19 @@ object SettingsDownloadScreen : SearchableSettings {
                                 stringResource(MR.strings.disabled)
                             } else {
                                 pluralStringResource(MR.plurals.next_unseen_episodes, count = it, it)
+                            }
+                        }
+                        .toImmutableMap(),
+                ),
+                Preference.PreferenceItem.ListPreference(
+                    pref = downloadPreferences.autoDownloadWhileReading(),
+                    title = stringResource(MR.strings.auto_download_while_reading),
+                    entries = listOf(0, 2, 3, 5, 10)
+                        .associateWith {
+                            if (it == 0) {
+                                stringResource(MR.strings.disabled)
+                            } else {
+                                pluralStringResource(MR.plurals.next_unread_chapters, count = it, it)
                             }
                         }
                         .toImmutableMap(),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -69,8 +69,8 @@ object SettingsLibraryScreen : SearchableSettings {
                 libraryPreferences,
             ),
             getGlobalUpdateGroup(allCategories, allAnimeCategories, libraryPreferences),
-            getChapterSwipeActionsGroup(libraryPreferences),
             getEpisodeSwipeActionsGroup(libraryPreferences),
+            getChapterSwipeActionsGroup(libraryPreferences),
         )
     }
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
@@ -187,16 +187,16 @@ object SettingsMainScreen : Screen() {
             screen = SettingsLibraryScreen,
         ),
         Item(
-            titleRes = MR.strings.pref_category_reader,
-            subtitleRes = MR.strings.pref_reader_summary,
-            icon = Icons.AutoMirrored.Outlined.ChromeReaderMode,
-            screen = SettingsReaderScreen,
-        ),
-        Item(
             titleRes = MR.strings.pref_category_player,
             subtitleRes = MR.strings.pref_player_summary,
             icon = Icons.Outlined.PlayCircleOutline,
             screen = SettingsPlayerScreen,
+        ),
+        Item(
+            titleRes = MR.strings.pref_category_reader,
+            subtitleRes = MR.strings.pref_reader_summary,
+            icon = Icons.AutoMirrored.Outlined.ChromeReaderMode,
+            screen = SettingsReaderScreen,
         ),
         Item(
             titleRes = MR.strings.pref_category_downloads,


### PR DESCRIPTION
Making the ordering or Anime and Manga related items consistent in settings


In Downloads (Download ahead): ![image](https://github.com/aniyomiorg/aniyomi/assets/5874051/3420f49a-2e59-4400-ac6b-d0badb9d0987)

In Library (Chapter Swipes): 
![image](https://github.com/aniyomiorg/aniyomi/assets/5874051/d98acd47-d66d-4425-b063-f7da82dc7721)


In Main Settings (Player then Reader): 
![image](https://github.com/aniyomiorg/aniyomi/assets/5874051/d8cdb3c2-9f81-40fe-b3b3-347e5d5aeda9)
