### PR TITLE
feat(browse): convert github urls

### DIFF
--- a/app/src/main/java/eu/kanade/domain/extension/anime/interactor/CreateAniyomiExtensionRepo.kt
+++ b/app/src/main/java/eu/kanade/domain/extension/anime/interactor/CreateAniyomiExtensionRepo.kt
@@ -35,4 +35,4 @@ class CreateAnimeExtensionRepo(private val preferences: SourcePreferences) {
 
 const val OFFICIAL_ANIYOMI_REPO_BASE_URL = "https://raw.githubusercontent.com/aniyomiorg/aniyomi-extensions/repo"
 private val repoRegex = """^https://.*/index\.min\.json$""".toRegex()
-private val githubRepoRegex = """https://github\.com/[^/]+/[^/]+/blob/(?:[^/]+/)+index\.min\.json""".toRegex()
+private val githubRepoRegex = """https://github\.com/[^/]+/[^/]+/blob/(?:[^/]+/)+index\.min\.json$""".toRegex()

--- a/app/src/main/java/eu/kanade/domain/extension/anime/interactor/CreateAniyomiExtensionRepo.kt
+++ b/app/src/main/java/eu/kanade/domain/extension/anime/interactor/CreateAniyomiExtensionRepo.kt
@@ -1,11 +1,22 @@
 package eu.kanade.domain.extension.anime.interactor
 
 import eu.kanade.domain.source.service.SourcePreferences
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import tachiyomi.core.preference.plusAssign
 
 class CreateAnimeExtensionRepo(private val preferences: SourcePreferences) {
 
     fun await(name: String): Result {
+        if (name.matches(githubRepoRegex)) {
+            val rawUrl = name.toHttpUrl().newBuilder().apply {
+                removePathSegment(2) // Remove /blob/
+                host("raw.githubusercontent.com")
+            }.build().toString()
+
+            preferences.animeExtensionRepos() += rawUrl.removeSuffix("/index.min.json")
+            return Result.Success
+        }
+
         // Do not allow invalid formats
         if (!name.matches(repoRegex) || name.startsWith(OFFICIAL_ANIYOMI_REPO_BASE_URL)) {
             return Result.InvalidUrl
@@ -24,3 +35,4 @@ class CreateAnimeExtensionRepo(private val preferences: SourcePreferences) {
 
 const val OFFICIAL_ANIYOMI_REPO_BASE_URL = "https://raw.githubusercontent.com/aniyomiorg/aniyomi-extensions/repo"
 private val repoRegex = """^https://.*/index\.min\.json$""".toRegex()
+private val githubRepoRegex = """https://github\.com/[^/]+/[^/]+/blob/(?:[^/]+/)+index\.min\.json""".toRegex()

--- a/app/src/main/java/eu/kanade/domain/extension/manga/interactor/CreateMangaExtensionRepo.kt
+++ b/app/src/main/java/eu/kanade/domain/extension/manga/interactor/CreateMangaExtensionRepo.kt
@@ -35,4 +35,4 @@ class CreateMangaExtensionRepo(private val preferences: SourcePreferences) {
 
 const val OFFICIAL_TACHIYOMI_REPO_BASE_URL = "https://raw.githubusercontent.com/tachiyomiorg/extensions/repo"
 private val repoRegex = """^https://.*/index\.min\.json$""".toRegex()
-private val githubRepoRegex = """https://github\.com/[^/]+/[^/]+/blob/(?:[^/]+/)+index\.min\.json""".toRegex()
+private val githubRepoRegex = """https://github\.com/[^/]+/[^/]+/blob/(?:[^/]+/)+index\.min\.json$""".toRegex()

--- a/app/src/main/java/eu/kanade/domain/extension/manga/interactor/CreateMangaExtensionRepo.kt
+++ b/app/src/main/java/eu/kanade/domain/extension/manga/interactor/CreateMangaExtensionRepo.kt
@@ -1,11 +1,22 @@
 package eu.kanade.domain.extension.manga.interactor
 
 import eu.kanade.domain.source.service.SourcePreferences
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import tachiyomi.core.preference.plusAssign
 
 class CreateMangaExtensionRepo(private val preferences: SourcePreferences) {
 
     fun await(name: String): Result {
+        if (name.matches(githubRepoRegex)) {
+            val rawUrl = name.toHttpUrl().newBuilder().apply {
+                removePathSegment(2) // Remove /blob/
+                host("raw.githubusercontent.com")
+            }.build().toString()
+
+            preferences.mangaExtensionRepos() += rawUrl.removeSuffix("/index.min.json")
+            return Result.Success
+        }
+
         // Do not allow invalid formats
         if (!name.matches(repoRegex) || name.startsWith(OFFICIAL_TACHIYOMI_REPO_BASE_URL)) {
             return Result.InvalidUrl
@@ -24,3 +35,4 @@ class CreateMangaExtensionRepo(private val preferences: SourcePreferences) {
 
 const val OFFICIAL_TACHIYOMI_REPO_BASE_URL = "https://raw.githubusercontent.com/tachiyomiorg/extensions/repo"
 private val repoRegex = """^https://.*/index\.min\.json$""".toRegex()
+private val githubRepoRegex = """https://github\.com/[^/]+/[^/]+/blob/(?:[^/]+/)+index\.min\.json""".toRegex()


### PR DESCRIPTION
Automatically convert urls like `https://github.com/user/repo/blob/repo/index.min.json` into `https://raw.githubusercontent.com/user/repo/repo/index.min.json` , helps if user inputs the wrong url.