### PR TITLE
feat: Add a setting to throttle downloads

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -1,17 +1,26 @@
 package eu.kanade.presentation.more.settings.screen
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.util.fastMap
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.presentation.category.visualName
 import eu.kanade.presentation.more.settings.Preference
+import eu.kanade.presentation.more.settings.widget.BasePreferenceWidget
 import eu.kanade.presentation.more.settings.widget.TriStateListDialog
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
@@ -23,6 +32,8 @@ import tachiyomi.domain.category.manga.interactor.GetMangaCategories
 import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.OutlinedNumericChooser
+import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.pluralStringResource
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
@@ -47,6 +58,7 @@ object SettingsDownloadScreen : SearchableSettings {
         )
         val downloadPreferences = remember { Injekt.get<DownloadPreferences>() }
         val basePreferences = remember { Injekt.get<BasePreferences>() }
+        val currentSpeedLimit = remember {mutableIntStateOf(downloadPreferences.downloadSpeedLimit().get()) }
         return listOf(
             Preference.PreferenceItem.SwitchPreference(
                 pref = downloadPreferences.downloadOnlyOverWifi(),
@@ -63,6 +75,34 @@ object SettingsDownloadScreen : SearchableSettings {
                 subtitle = stringResource(MR.strings.multi_thread_download_threads_number_summary),
                 entries = (1..64).associateWith { it.toString() }.toImmutableMap(),
             ),
+            Preference.PreferenceItem.CustomPreference(
+                title = stringResource(MR.strings.download_speed_limit),
+            ) {
+                BasePreferenceWidget(
+                    subcomponent = {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = MaterialTheme.padding.medium),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceEvenly,
+                        ) {
+                            OutlinedNumericChooser(
+                                label = stringResource(MR.strings.download_speed_limit),
+                                placeholder = "0",
+                                suffix = "kB/s",
+                                value = currentSpeedLimit.value,
+                                step = 100,
+                                min = 0,
+                                onValueChanged = {
+                                    downloadPreferences.downloadSpeedLimit().set(it)
+                                    currentSpeedLimit.value = it
+                                },
+                            )
+                        }
+                    },
+                )
+            },
             Preference.PreferenceItem.SwitchPreference(
                 pref = downloadPreferences.saveChaptersAsCBZ(),
                 title = stringResource(MR.strings.save_chapter_as_cbz),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -58,7 +58,7 @@ object SettingsDownloadScreen : SearchableSettings {
         )
         val downloadPreferences = remember { Injekt.get<DownloadPreferences>() }
         val basePreferences = remember { Injekt.get<BasePreferences>() }
-        val currentSpeedLimit = remember {mutableIntStateOf(downloadPreferences.downloadSpeedLimit().get()) }
+        val currentSpeedLimit = remember { mutableIntStateOf(downloadPreferences.downloadSpeedLimit().get()) }
         return listOf(
             Preference.PreferenceItem.SwitchPreference(
                 pref = downloadPreferences.downloadOnlyOverWifi(),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -98,7 +98,7 @@ object SettingsDownloadScreen : SearchableSettings {
                 subtitle = if (speedLimit == 0) {
                     stringResource(MR.strings.off)
                 } else {
-                    "$speedLimit kB/s"
+                    "$speedLimit KiB/s"
                 },
                 onClick = { showDownloadLimitDialog = true },
             ),
@@ -409,7 +409,7 @@ object SettingsDownloadScreen : SearchableSettings {
                         OutlinedNumericChooser(
                             label = stringResource(MR.strings.download_speed_limit),
                             placeholder = "0",
-                            suffix = "kB/s",
+                            suffix = "KiB/s",
                             value = initialValue,
                             step = 100,
                             min = 0,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
@@ -827,7 +827,7 @@ class AnimeDownloader(
                 // Write to file with pause/resume capability
                 try {
                     throttler.apply {
-                        bytesPerSecond(preferences.downloadSpeedLimit().get().toLong() * 1024, 4086,  8192)
+                        bytesPerSecond(preferences.downloadSpeedLimit().get().toLong() * 1024, 4086, 8192)
                     }
                     response.body.source().use { source ->
                         file.openOutputStream(true).use { output ->

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import logcat.LogPriority
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okio.Throttler
 import okio.buffer
 import okio.sink
 import rx.subjects.PublishSubject
@@ -91,6 +92,11 @@ class AnimeDownloader(
      * Notifier for the downloader state and progress.
      */
     private val notifier by lazy { AnimeDownloadNotifier(context) }
+
+    /**
+     * The throttler used to control the download speed.
+     */
+    private val throttler = Throttler()
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var downloaderJob: Job? = null
@@ -706,12 +712,14 @@ class AnimeDownloader(
                         contentLength: Long,
                         done: Boolean,
                     ) {
-                        val progress = (((bytesRead * 90 / (range[1] - range[0])) * splitWeight).toInt()) + 1
+                        val progress = (((bytesRead * 90 / (range[1] - range[0])) * splitWeight).toInt())
                         totalProgresses[rangeList.indexOf(range)] = progress
                         video.progress = min(totalProgresses.reduce(Int::plus), 90)
                     }
                 }
-
+            throttler.apply {
+                bytesPerSecond(preferences.downloadSpeedLimit().get().toLong() * 1024)
+            }
             partJobList.add(
                 scope.launchIO {
                     try {
@@ -728,8 +736,9 @@ class AnimeDownloader(
                                     val sink = output.sink().buffer()
                                     val buffer = ByteArray(4 * 1024)
                                     var totalBytesRead = 0L
-                                    var bytesRead: Int = source.read(buffer)
-                                    while (bytesRead.toLong() != -1L) {
+                                    var bytesRead: Int
+                                    val throttledSource = throttler.source(source).buffer()
+                                    while (throttledSource.read(buffer).also { bytesRead = it }.toLong() != -1L) {
                                         // Check if the download is paused, if so, wait
                                         while (isPaused) {
                                             delay(1000) // Wait for 1 second before checking again
@@ -738,10 +747,10 @@ class AnimeDownloader(
                                         sink.write(buffer, 0, bytesRead)
                                         sink.emitCompleteSegments()
                                         totalBytesRead += bytesRead
-                                        bytesRead = source.read(buffer)
                                     }
                                     sink.flush()
                                     sink.close()
+                                    throttledSource.close()
                                 }
                             }
                         } catch (e: Exception) {
@@ -777,7 +786,8 @@ class AnimeDownloader(
             }
             file0.renameTo("$filename.mp4")
         } catch (e: Exception) {
-            throw e
+            logcat(LogPriority.ERROR, e)
+            failed = true
         }
         if (failed) {
             for (i in 0 until nParts) {
@@ -802,7 +812,6 @@ class AnimeDownloader(
         while (isPaused) {
             delay(1000) // This is a pause check delay, adjust the timing as needed.
         }
-
         when {
             isHls(video) || isMpd(video) -> {
                 return ffmpegDownload(video, download, tmpDir, filename)
@@ -817,13 +826,17 @@ class AnimeDownloader(
                 val file = tmpDir.findFile("$filename.tmp") ?: tmpDir.createFile("$filename.tmp")!!
                 // Write to file with pause/resume capability
                 try {
+                    throttler.apply {
+                        bytesPerSecond(preferences.downloadSpeedLimit().get().toLong() * 1024, 4086,  8192)
+                    }
                     response.body.source().use { source ->
                         file.openOutputStream(true).use { output ->
                             val sink = output.sink().buffer()
                             val buffer = ByteArray(4 * 1024)
                             var totalBytesRead = 0L
                             var bytesRead: Int
-                            while (source.read(buffer).also { bytesRead = it }.toLong() != -1L) {
+                            val throttledSource = throttler.source(source).buffer()
+                            while (throttledSource.read(buffer).also { bytesRead = it }.toLong() != -1L) {
                                 // Check if the download is paused, if so, wait
                                 while (isPaused) {
                                     delay(1000) // Wait for 1 second before checking again
@@ -834,6 +847,9 @@ class AnimeDownloader(
                                 totalBytesRead += bytesRead
                                 // Update progress here if needed
                             }
+                            sink.flush()
+                            sink.close()
+                            throttledSource.close()
                         }
                     }
                     // After download is complete, rename the file to its final name

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
@@ -702,6 +702,10 @@ class AnimeDownloader(
         val totalProgresses = mutableListOf<Int>()
         totalProgresses.addAll(List(nParts) { 0 })
 
+        val multipartThrottler = Throttler().apply {
+            bytesPerSecond(preferences.downloadSpeedLimit().get().toLong() * 1024 / nParts)
+        }
+
         for (range in rangeList) {
             val splitWeight = (range[1] - range[0]).toFloat() / size.toFloat()
             // create a listener for each part, so we can update the progress generally
@@ -717,9 +721,6 @@ class AnimeDownloader(
                         video.progress = min(totalProgresses.reduce(Int::plus), 90)
                     }
                 }
-            throttler.apply {
-                bytesPerSecond(preferences.downloadSpeedLimit().get().toLong() * 1024)
-            }
             partJobList.add(
                 scope.launchIO {
                     try {
@@ -737,7 +738,7 @@ class AnimeDownloader(
                                     val buffer = ByteArray(4 * 1024)
                                     var totalBytesRead = 0L
                                     var bytesRead: Int
-                                    val throttledSource = throttler.source(source).buffer()
+                                    val throttledSource = multipartThrottler.source(source).buffer()
                                     while (throttledSource.read(buffer).also { bytesRead = it }.toLong() != -1L) {
                                         // Check if the download is paused, if so, wait
                                         while (isPaused) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
@@ -827,7 +827,7 @@ class AnimeDownloader(
                 // Write to file with pause/resume capability
                 try {
                     throttler.apply {
-                        bytesPerSecond(preferences.downloadSpeedLimit().get().toLong() * 1024, 4086, 8192)
+                        bytesPerSecond(preferences.downloadSpeedLimit().get().toLong() * 1024, 4096, 8192)
                     }
                     response.body.source().use { source ->
                         file.openOutputStream(true).use { output ->

--- a/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
@@ -66,6 +66,6 @@ class DownloadPreferences(
 
     fun numberOfDownloads() = preferenceStore.getInt("download_slots", 1)
     fun multithreadingDownload() = preferenceStore.getBoolean("multi_part_download", false)
-
     fun numberOfThreads() = preferenceStore.getInt("download_threads", 4)
+    fun downloadSpeedLimit() = preferenceStore.getInt("download_speed_limit", 0)
 }

--- a/i18n/src/commonMain/resources/MR/base/strings-aniyomi.xml
+++ b/i18n/src/commonMain/resources/MR/base/strings-aniyomi.xml
@@ -337,4 +337,5 @@
     <string name="multi_thread_download_summary">Enable downloading anime using multiple threads</string>
     <string name="multi_thread_download_threads_number">Thread count</string>
     <string name="multi_thread_download_threads_number_summary">Number of threads to use for downloading, might get your IP blocked if too high, usually 4 is a good number to avoid heavy load on source servers.</string>
+    <string name="download_speed_limit">Download Speed Threshold</string>
 </resources>

--- a/i18n/src/commonMain/resources/MR/base/strings-aniyomi.xml
+++ b/i18n/src/commonMain/resources/MR/base/strings-aniyomi.xml
@@ -338,5 +338,6 @@
     <string name="multi_thread_download_summary">Enable downloading anime using multiple threads</string>
     <string name="multi_thread_download_threads_number">Thread count</string>
     <string name="multi_thread_download_threads_number_summary">Number of threads to use for downloading, might get your IP blocked if too high, usually 4 is a good number to avoid heavy load on source servers.</string>
-    <string name="download_speed_limit">Download Speed Threshold</string>
+    <string name="download_speed_limit">Download speed limit</string>
+    <string name="download_speed_limit_hint">Set to 0 to disable the speed limit.</string>
 </resources>


### PR DESCRIPTION
Implemented a speed limiter for mp4 downloads using okio Throttler class, will overshoot the target initially if a lot of threads are enabled.

Partially closes #157 since ffmpeg downloads will not be limited

![photo_2024-01-16_10-37-54](https://github.com/aniyomiorg/aniyomi/assets/43270431/aeb9fb11-2af1-4bc2-a837-29db9afbd191)
