### PR TITLE
Use the font available in mpv's assets instead of system's

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/sheets/subtitle/SubtitleSettingsSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/sheets/subtitle/SubtitleSettingsSheet.kt
@@ -168,7 +168,7 @@ fun SubtitlePreview(
     val fontFile = fontMap.keys.firstOrNull { it.contains(font, true) }
         ?.let {
             Typeface.createFromFile(fontMap[it]?.let { fontFile -> tempFileManager.createTempFile(fontFile) })
-        } ?: Typeface.SANS_SERIF
+        } ?: Typeface.createFromAsset(LocalContext.current.assets, "subfont.ttf")
 
     Box(
         modifier = Modifier


### PR DESCRIPTION
Use the font in mpv-android's assets directory instead of `Typeface.SANS_SERIF` since that can be affected with system customization
If your changes are visual, please provide images below:
### Preview of how preview looks with custom system fonts before and after the change
| Before | After |
| ------- | ------- |
| ![Screenshot_20240116-214402](https://github.com/aniyomiorg/aniyomi/assets/54363735/1af4190f-1d1c-4dc5-8c59-22810b160cad) | ![Screenshot_20240116-214446](https://github.com/aniyomiorg/aniyomi/assets/54363735/2db1bb10-40cb-4c85-b02f-a126974d81fc) |
