### PR TITLE
fix: separator when scanlator exists

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/entries/anime/components/AnimeEpisodeListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/anime/components/AnimeEpisodeListItem.kt
@@ -188,9 +188,9 @@ fun AnimeEpisodeListItem(
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
                                 )
-                                if (watchProgress != null || scanlator != null) DotSeparatorText()
                             }
                             if (watchProgress != null) {
+                                DotSeparatorText()
                                 Text(
                                     text = watchProgress,
                                     maxLines = 1,
@@ -200,6 +200,7 @@ fun AnimeEpisodeListItem(
                                 if (scanlator != null) DotSeparatorText()
                             }
                             if (scanlator != null) {
+                                DotSeparatorText()
                                 Text(
                                     text = scanlator,
                                     maxLines = 1,

--- a/app/src/main/java/eu/kanade/presentation/entries/manga/components/MangaChapterListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/manga/components/MangaChapterListItem.kt
@@ -187,14 +187,6 @@ fun MangaChapterListItem(
                                     overflow = TextOverflow.Ellipsis,
                                 )
                             }
-                            if (scanlator != null) {
-                                DotSeparatorText()
-                                Text(
-                                    text = scanlator,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            }
                             if (readProgress != null) {
                                 DotSeparatorText()
                                 Text(
@@ -202,6 +194,14 @@ fun MangaChapterListItem(
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
                                     color = LocalContentColor.current.copy(alpha = ReadItemAlpha),
+                                )
+                            }
+                            if (scanlator != null) {
+                                DotSeparatorText()
+                                Text(
+                                    text = scanlator,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
                                 )
                             }
                         }

--- a/app/src/main/java/eu/kanade/presentation/entries/manga/components/MangaChapterListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/manga/components/MangaChapterListItem.kt
@@ -186,21 +186,22 @@ fun MangaChapterListItem(
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
                                 )
-                                if (readProgress != null || scanlator != null) DotSeparatorText()
+                            }
+                            if (scanlator != null) {
+                                DotSeparatorText()
+                                Text(
+                                    text = scanlator,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
                             }
                             if (readProgress != null) {
+                                DotSeparatorText()
                                 Text(
                                     text = readProgress,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
                                     color = LocalContentColor.current.copy(alpha = ReadItemAlpha),
-                                )
-                            }
-                            if (scanlator != null) {
-                                Text(
-                                    text = scanlator,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
                                 )
                             }
                         }


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
closes #1337
![aaaaaaaaaaaaa](https://github.com/aniyomiorg/aniyomi/assets/80992641/5731bc58-835c-4b8b-a3ea-9e0dcd882d68)
