### PR TITLE
feat(episode-options): add play internally option

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/entries/anime/EpisodeOptionsDialogScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/anime/EpisodeOptionsDialogScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.Input
 import androidx.compose.material.icons.outlined.NavigateNext
 import androidx.compose.material.icons.outlined.OpenInNew
 import androidx.compose.material.icons.outlined.SystemUpdateAlt
@@ -256,6 +257,18 @@ private fun VideoList(
                             )
                         }
                     },
+                    onIntPlayerClicked = {
+                        scope.launch {
+                            MainActivity.startPlayerActivity(
+                                context,
+                                anime.id,
+                                episode.id,
+                                false,
+                                selectedVideo,
+                                videoList,
+                            )
+                        }
+                    },
                 )
             }
         }
@@ -289,6 +302,7 @@ private fun QualityOptions(
     onExtDownloadClicked: () -> Unit = {},
     onCopyClicked: () -> Unit = {},
     onExtPlayerClicked: () -> Unit = {},
+    onIntPlayerClicked: () -> Unit = {},
 ) {
     val closeMenu = { EpisodeOptionsDialogScreen.onDismissDialog() }
 
@@ -322,6 +336,15 @@ private fun QualityOptions(
             icon = Icons.Outlined.OpenInNew,
             onClick = {
                 onExtPlayerClicked()
+                closeMenu()
+            },
+        )
+
+        ClickableRow(
+            text = stringResource(MR.strings.action_play_internally),
+            icon = Icons.Outlined.Input,
+            onClick = {
+                onIntPlayerClicked()
                 closeMenu()
             },
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -572,6 +572,7 @@ class MainActivity : BaseActivity() {
             episodeId: Long,
             extPlayer: Boolean,
             video: Video? = null,
+            videoList: List<Video>? = null,
         ) {
             if (extPlayer) {
                 val intent = try {
@@ -583,7 +584,9 @@ class MainActivity : BaseActivity() {
                 }
                 externalPlayerResult?.launch(intent) ?: return
             } else {
-                context.startActivity(PlayerActivity.newIntent(context, animeId, episodeId))
+                context.startActivity(
+                    PlayerActivity.newIntent(context, animeId, episodeId, videoList, videoList?.indexOf(video)),
+                )
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -13,6 +13,7 @@ import eu.kanade.domain.track.anime.interactor.TrackEpisode
 import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.tachiyomi.animesource.AnimeSource
+import eu.kanade.tachiyomi.animesource.model.SerializableVideo.Companion.toVideoList
 import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
@@ -233,7 +234,12 @@ class PlayerViewModel @JvmOverloads constructor(
      * Initializes this presenter with the given [animeId] and [initialEpisodeId]. This method will
      * fetch the anime from the database and initialize the episode.
      */
-    suspend fun init(animeId: Long, initialEpisodeId: Long): Pair<InitResult, Result<Boolean>> {
+    suspend fun init(
+        animeId: Long,
+        initialEpisodeId: Long,
+        vidList: String,
+        vidIndex: Int,
+    ): Pair<InitResult, Result<Boolean>> {
         val defaultResult = InitResult(currentVideoList, 0, null)
         if (!needsInit()) return Pair(defaultResult, Result.success(true))
         return try {
@@ -252,13 +258,21 @@ class PlayerViewModel @JvmOverloads constructor(
 
                 val currentEp = currentEpisode ?: throw Exception("No episode loaded.")
 
-                EpisodeLoader.getLinks(currentEp.toDomainEpisode()!!, anime, source)
-                    .takeIf { it.isNotEmpty() }
-                    ?.also { currentVideoList = it }
-                    ?: run {
+                if (vidList.isNotBlank()) {
+                    currentVideoList = vidList.toVideoList().ifEmpty {
                         currentVideoList = null
-                        throw Exception("Video list is empty.")
+                        throw Exception("Video selected from empty list?")
                     }
+                    qualityIndex = vidIndex
+                } else {
+                    EpisodeLoader.getLinks(currentEp.toDomainEpisode()!!, anime, source)
+                        .takeIf { it.isNotEmpty() }
+                        ?.also { currentVideoList = it }
+                        ?: run {
+                            currentVideoList = null
+                            throw Exception("Video list is empty.")
+                        }
+                }
 
                 val result = InitResult(
                     videoList = currentVideoList,


### PR DESCRIPTION
Inspired by #1250

This could be useful when always play externally is on and internal player is needed for a single episode. This is currently possible in the bottom sheet episode menu.