### PR TITLE
Fixed update_check_no_fixed new_updates pop up not working #1298

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
@@ -220,10 +220,10 @@ object AboutScreen : Screen() {
                         onAvailableUpdate(result)
                     }
                     is GetApplicationRelease.Result.NoNewUpdate -> {
-                        context.stringResource(MR.strings.update_check_no_new_updates)
+                        context.toast(context.stringResource(MR.strings.update_check_no_new_updates))
                     }
                     is GetApplicationRelease.Result.OsTooOld -> {
-                        context.stringResource(MR.strings.update_check_eol)
+                        context.toast(context.stringResource(MR.strings.update_check_eol))
                     }
                     else -> {}
                 }


### PR DESCRIPTION
I have added the toast extension function on the Context to display a toast message with the appropriate string resource whenever the OS is too old for new updates or there are no new updates.

fixes #1298
