### PR TITLE
feat(player): add audio channels settings

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
@@ -33,6 +33,7 @@ import eu.kanade.tachiyomi.ui.player.VLC_PLAYER
 import eu.kanade.tachiyomi.ui.player.WEB_VIDEO_CASTER
 import eu.kanade.tachiyomi.ui.player.X_PLAYER
 import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
+import eu.kanade.tachiyomi.ui.player.viewer.AudioChannels
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableList
@@ -109,14 +110,10 @@ object SettingsPlayerScreen : SearchableSettings {
                     pref = playerAudioChannels,
                     title = stringResource(MR.strings.pref_player_audio_channels),
                     entries = persistentMapOf(
-                        AudioChannels.Auto to
-                            stringResource(MR.strings.pref_player_audio_channels_auto),
-                        AudioChannels.Mono to
-                            stringResource(MR.strings.pref_player_audio_channels_mono),
-                        AudioChannels.Stereo to
-                            stringResource(MR.strings.pref_player_audio_channels_stereo),
-                        AudioChannels.ReverseStereo to
-                            stringResource(MR.strings.pref_player_audio_channels_reverse_stereo),
+                        AudioChannels.Auto to stringResource(AudioChannels.Auto.textRes),
+                        AudioChannels.Mono to stringResource(AudioChannels.Mono.textRes),
+                        AudioChannels.Stereo to stringResource(AudioChannels.Stereo.textRes),
+                        AudioChannels.ReverseStereo to stringResource(AudioChannels.ReverseStereo.textRes),
                     ),
                 ),
                 Preference.PreferenceItem.TextPreference(
@@ -453,10 +450,3 @@ val externalPlayers = listOf(
     X_PLAYER,
     WEB_VIDEO_CASTER,
 )
-
-enum class AudioChannels(val propertyName: String, val propertyValue: String) {
-    Auto("audio-channels", "auto"),
-    Mono("audio-channels", "mono"),
-    Stereo("audio-channels", "stereo"),
-    ReverseStereo("af", "pan=[stereo|c0=c1|c1=c0]"),
-}

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
@@ -90,6 +90,7 @@ object SettingsPlayerScreen : SearchableSettings {
     private fun getInternalPlayerGroup(playerPreferences: PlayerPreferences): Preference.PreferenceGroup {
         val playerFullscreen = playerPreferences.playerFullscreen()
         val playerHideControls = playerPreferences.hideControls()
+        val playerAudioChannels = playerPreferences.audioChannels()
         val navigator = LocalNavigator.currentOrThrow
 
         return Preference.PreferenceGroup(
@@ -103,6 +104,20 @@ object SettingsPlayerScreen : SearchableSettings {
                 Preference.PreferenceItem.SwitchPreference(
                     pref = playerHideControls,
                     title = stringResource(MR.strings.pref_player_hide_controls),
+                ),
+                Preference.PreferenceItem.ListPreference(
+                    pref = playerAudioChannels,
+                    title = stringResource(MR.strings.pref_player_audio_channels),
+                    entries = persistentMapOf(
+                        AudioChannels.Auto to
+                            stringResource(MR.strings.pref_player_audio_channels_auto),
+                        AudioChannels.Mono to
+                            stringResource(MR.strings.pref_player_audio_channels_mono),
+                        AudioChannels.Stereo to
+                            stringResource(MR.strings.pref_player_audio_channels_stereo),
+                        AudioChannels.ReverseStereo to
+                            stringResource(MR.strings.pref_player_audio_channels_reverse_stereo),
+                    ),
                 ),
                 Preference.PreferenceItem.TextPreference(
                     title = stringResource(MR.strings.pref_category_player_advanced),
@@ -438,3 +453,10 @@ val externalPlayers = listOf(
     X_PLAYER,
     WEB_VIDEO_CASTER,
 )
+
+enum class AudioChannels(val propertyName: String, val propertyValue: String) {
+    Auto("audio-channels", "auto"),
+    Mono("audio-channels", "mono"),
+    Stereo("audio-channels", "stereo"),
+    ReverseStereo("af", "pan=[stereo|c0=c1|c1=c0]"),
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -606,6 +606,7 @@ class PlayerActivity : BaseActivity() {
     private fun setupPlayerAudio() {
         with(playerPreferences) {
             audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+            val audioChannel = audioChannels().get()
 
             val useDeviceVolume = playerVolumeValue().get() == -1.0F || !rememberPlayerVolume().get()
             fineVolume = if (useDeviceVolume) {
@@ -617,6 +618,8 @@ class PlayerActivity : BaseActivity() {
             if (rememberAudioDelay().get()) {
                 MPVLib.setPropertyDouble("audio-delay", (audioDelay().get() / 1000.0))
             }
+
+            MPVLib.setOptionString(audioChannel.propertyName, audioChannel.propertyValue)
         }
 
         verticalScrollRight(0F)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
@@ -1,8 +1,10 @@
 package eu.kanade.tachiyomi.ui.player.settings
 
+import eu.kanade.presentation.more.settings.screen.AudioChannels
 import eu.kanade.tachiyomi.ui.player.viewer.AspectState
 import eu.kanade.tachiyomi.ui.player.viewer.HwDecState
 import tachiyomi.core.preference.PreferenceStore
+import tachiyomi.core.preference.getEnum
 
 class PlayerPreferences(
     private val preferenceStore: PreferenceStore,
@@ -22,6 +24,8 @@ class PlayerPreferences(
 
     fun rememberPlayerVolume() = preferenceStore.getBoolean("pref_remember_volume", false)
     fun playerVolumeValue() = preferenceStore.getFloat("player_volume_value", -1.0F)
+
+    fun audioChannels() = preferenceStore.getEnum("pref_audio_config", AudioChannels.Auto)
 
     fun autoplayEnabled() = preferenceStore.getBoolean("pref_auto_play_enabled", false)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
@@ -1,7 +1,7 @@
 package eu.kanade.tachiyomi.ui.player.settings
 
-import eu.kanade.presentation.more.settings.screen.AudioChannels
 import eu.kanade.tachiyomi.ui.player.viewer.AspectState
+import eu.kanade.tachiyomi.ui.player.viewer.AudioChannels
 import eu.kanade.tachiyomi.ui.player.viewer.HwDecState
 import tachiyomi.core.preference.PreferenceStore
 import tachiyomi.core.preference.getEnum

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/viewer/PlayerEnums.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/viewer/PlayerEnums.kt
@@ -84,3 +84,14 @@ enum class PlayerStatsPage(val page: Int, val textRes: StringResource) {
     PAGE2(2, MR.strings.player_statistics_page_2),
     PAGE3(3, MR.strings.player_statistics_page_3),
 }
+
+enum class AudioChannels(val propertyName: String, val propertyValue: String, val textRes: StringResource) {
+    Auto("audio-channels", "auto", MR.strings.pref_player_audio_channels_auto),
+    Mono("audio-channels", "mono", MR.strings.pref_player_audio_channels_mono),
+    Stereo("audio-channels", "stereo", MR.strings.pref_player_audio_channels_stereo),
+    ReverseStereo(
+        "af",
+        "pan=[stereo|c0=c1|c1=c0]",
+        MR.strings.pref_player_audio_channels_reverse_stereo,
+    ),
+}

--- a/i18n/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n/src/commonMain/resources/MR/base/strings.xml
@@ -906,6 +906,11 @@
     <string name="pref_player_smooth_seek_summary">When enabled, seeking will not focus on keyframes, leading to slower but precise seeking</string>
     <string name="pref_player_fullscreen">Show content in display cutout</string>
     <string name="pref_player_hide_controls">Hide player controls when opening the player</string>
+    <string name="pref_player_audio_channels">Audio channels</string>
+    <string name="pref_player_audio_channels_auto">Auto</string>
+    <string name="pref_player_audio_channels_mono">Mono</string>
+    <string name="pref_player_audio_channels_stereo">Stereo</string>
+    <string name="pref_player_audio_channels_reverse_stereo">Reverse stereo</string>
     <string name="pref_category_pip">Picture-in-Picture (PiP)</string>
     <string name="pref_enable_pip">Enable the use of PiP mode</string>
     <string name="pref_pip_episode_toasts">Show episode toasts when switching episodes in PiP mode</string>


### PR DESCRIPTION
As the title suggests, this PR adds a setting that allows users to change what audio channels the player should use.
currently there are only for options: Auto, Mono, Stereo and Reverse Stereo.
can be changed through Settings -> Player -> Audio channels
like so
| In the settings | in the player settings sheet |
| ------- | ------- |
| ![image](https://github.com/aniyomiorg/aniyomi/assets/54363735/baf9473d-c522-40d4-b5e0-f94395326e6d)|![image](https://github.com/aniyomiorg/aniyomi/assets/54363735/a6eea0a9-ec16-4ab4-93a1-95e79148215d) |

