### PR TITLE
fix(pip): fix pip crash cause by mpv versions in main activity

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoriesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoriesTab.kt
@@ -51,7 +51,6 @@ object HistoriesTab : Tab() {
 
     @Composable
     override fun Content() {
-        throw RuntimeException()
         val context = LocalContext.current
         val fromMore = currentNavigationStyle() == NavStyle.MOVE_HISTORY_TO_MORE
         // Hoisted for history tab's search bar

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoriesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoriesTab.kt
@@ -51,6 +51,7 @@ object HistoriesTab : Tab() {
 
     @Composable
     override fun Content() {
+        throw RuntimeException()
         val context = LocalContext.current
         val fromMore = currentNavigationStyle() == NavStyle.MOVE_HISTORY_TO_MORE
         // Hoisted for history tab's search bar

--- a/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
@@ -5,7 +5,6 @@ import android.os.Build
 import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.extension.anime.AnimeExtensionManager
 import eu.kanade.tachiyomi.extension.manga.MangaExtensionManager
-import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.WebViewUtil
 import eu.kanade.tachiyomi.util.system.createFileInCacheDir
@@ -21,6 +20,8 @@ class CrashLogUtil(
     private val mangaExtensionManager: MangaExtensionManager = Injekt.get(),
     private val animeExtensionManager: AnimeExtensionManager = Injekt.get(),
 ) {
+
+    private val mpvVersions = MpvVersionsUtil(context).mpvVersions
 
     suspend fun dumpLogs() = withNonCancellableContext {
         try {
@@ -49,9 +50,9 @@ class CrashLogUtil(
             Device name: ${Build.DEVICE} (${Build.PRODUCT})
             Device model: ${Build.MODEL}
             WebView: ${WebViewUtil.getVersion(context)}
-            MPVLib version: ${MainActivity.mpvVersions.mpvCommit} (${MainActivity.mpvVersions.buildDate})
-            Libplacebo version: ${MainActivity.mpvVersions.libPlacebo}
-            FFmpeg version: ${MainActivity.mpvVersions.ffmpeg}
+            MPVLib version: ${mpvVersions.mpvCommit} (${mpvVersions.buildDate})
+            Libplacebo version: ${mpvVersions.libPlacebo}
+            FFmpeg version: ${mpvVersions.ffmpeg}
         """.trimIndent()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/MpvVersionsUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/MpvVersionsUtil.kt
@@ -1,0 +1,63 @@
+package eu.kanade.tachiyomi.util
+
+import android.content.Context
+import `is`.xyz.mpv.MPVLib
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+class MpvVersionsUtil(context: Context) : MPVLib.LogObserver {
+
+    val mpvVersions = MPVVersions()
+
+    private var recordMPVLog = true
+
+    init {
+        MPVLib.create(context, "v")
+        MPVLib.addLogObserver(this)
+        MPVLib.init()
+    }
+
+    override fun logMessage(prefix: String, level: Int, text: String) {
+        if (prefix != "cplayer") return
+
+        if (level == MPVLib.mpvLogLevel.MPV_LOG_LEVEL_V) {
+            with(text) {
+                if (recordMPVLog) {
+                    when {
+                        contains("Copyright ©") -> mpvVersions.mpvCommit = this
+                        contains("built on") -> mpvVersions.buildDate = this
+                        contains("libplacebo version:") -> mpvVersions.libPlacebo = this
+                        contains("FFmpeg version:") -> mpvVersions.ffmpeg = this
+                        else -> {
+                            recordMPVLog = false
+                            runBlocking { onLoggingComplete() }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun onLoggingComplete() {
+        withContext(Dispatchers.IO) {
+            mpvVersions.trim()
+            MPVLib.removeLogObserver(this@MpvVersionsUtil)
+            MPVLib.destroy()
+        }
+    }
+
+    data class MPVVersions(
+        var mpvCommit: String = "",
+        var buildDate: String = "",
+        var libPlacebo: String = "",
+        var ffmpeg: String = "",
+    ) {
+        fun trim() {
+            mpvCommit = mpvCommit.substringBefore("Copyright").trim()
+            buildDate = buildDate.substringAfter("built on ").trim()
+            libPlacebo = libPlacebo.substringAfter(": ").trim()
+            ffmpeg = ffmpeg.substringAfter(": ").trim()
+        }
+    }
+}


### PR DESCRIPTION
this should fix the crash caused by opening pip
caveat: it *does* introduce a race condition in the crash activity between the activity itself being shown and mpv printing the logs in time for activity to display, but it's better than slowing down the activity ig