### PR TITLE
Add auto-safe as (default) audio channel

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsPlayerScreen.kt
@@ -110,6 +110,7 @@ object SettingsPlayerScreen : SearchableSettings {
                     pref = playerAudioChannels,
                     title = stringResource(MR.strings.pref_player_audio_channels),
                     entries = persistentMapOf(
+                        AudioChannels.AutoSafe to stringResource(AudioChannels.AutoSafe.textRes),
                         AudioChannels.Auto to stringResource(AudioChannels.Auto.textRes),
                         AudioChannels.Mono to stringResource(AudioChannels.Mono.textRes),
                         AudioChannels.Stereo to stringResource(AudioChannels.Stereo.textRes),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
@@ -25,7 +25,7 @@ class PlayerPreferences(
     fun rememberPlayerVolume() = preferenceStore.getBoolean("pref_remember_volume", false)
     fun playerVolumeValue() = preferenceStore.getFloat("player_volume_value", -1.0F)
 
-    fun audioChannels() = preferenceStore.getEnum("pref_audio_config", AudioChannels.Auto)
+    fun audioChannels() = preferenceStore.getEnum("pref_audio_config", AudioChannels.AutoSafe)
 
     fun autoplayEnabled() = preferenceStore.getBoolean("pref_auto_play_enabled", false)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/viewer/PlayerEnums.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/viewer/PlayerEnums.kt
@@ -86,6 +86,7 @@ enum class PlayerStatsPage(val page: Int, val textRes: StringResource) {
 }
 
 enum class AudioChannels(val propertyName: String, val propertyValue: String, val textRes: StringResource) {
+    AutoSafe("audio-channels", "auto-safe", MR.strings.pref_player_audio_channels_auto_safe),
     Auto("audio-channels", "auto", MR.strings.pref_player_audio_channels_auto),
     Mono("audio-channels", "mono", MR.strings.pref_player_audio_channels_mono),
     Stereo("audio-channels", "stereo", MR.strings.pref_player_audio_channels_stereo),

--- a/i18n/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n/src/commonMain/resources/MR/base/strings.xml
@@ -907,6 +907,7 @@
     <string name="pref_player_fullscreen">Show content in display cutout</string>
     <string name="pref_player_hide_controls">Hide player controls when opening the player</string>
     <string name="pref_player_audio_channels">Audio channels</string>
+    <string name="pref_player_audio_channels_auto_safe">Auto-safe</string>
     <string name="pref_player_audio_channels_auto">Auto</string>
     <string name="pref_player_audio_channels_mono">Mono</string>
     <string name="pref_player_audio_channels_stereo">Stereo</string>


### PR DESCRIPTION
reference: [mpv documentation](https://mpv.io/manual/master/#options-audio-channels)