### PR TITLE
feat(repo): remove default manga repo

### DIFF
--- a/app/src/main/java/eu/kanade/domain/extension/manga/interactor/CreateMangaExtensionRepo.kt
+++ b/app/src/main/java/eu/kanade/domain/extension/manga/interactor/CreateMangaExtensionRepo.kt
@@ -18,7 +18,7 @@ class CreateMangaExtensionRepo(private val preferences: SourcePreferences) {
         }
 
         // Do not allow invalid formats
-        if (!name.matches(repoRegex) || name.startsWith(OFFICIAL_TACHIYOMI_REPO_BASE_URL)) {
+        if (!name.matches(repoRegex)) {
             return Result.InvalidUrl
         }
 
@@ -33,6 +33,5 @@ class CreateMangaExtensionRepo(private val preferences: SourcePreferences) {
     }
 }
 
-const val OFFICIAL_TACHIYOMI_REPO_BASE_URL = "https://raw.githubusercontent.com/tachiyomiorg/extensions/repo"
 private val repoRegex = """^https://.*/index\.min\.json$""".toRegex()
 private val githubRepoRegex = """https://github\.com/[^/]+/[^/]+/blob/(?:[^/]+/)+index\.min\.json$""".toRegex()

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/api/MangaExtensionApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/api/MangaExtensionApi.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.extension.manga.api
 
 import android.content.Context
-import eu.kanade.domain.extension.manga.interactor.OFFICIAL_TACHIYOMI_REPO_BASE_URL
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.extension.ExtensionUpdateNotifier
 import eu.kanade.tachiyomi.extension.manga.MangaExtensionManager
@@ -37,9 +36,8 @@ internal class MangaExtensionApi {
 
     suspend fun findExtensions(): List<MangaExtension.Available> {
         return withIOContext {
-            val extensions = buildList {
-                addAll(getExtensions(OFFICIAL_TACHIYOMI_REPO_BASE_URL))
-                sourcePreferences.mangaExtensionRepos().get().map { addAll(getExtensions(it)) }
+            val extensions = sourcePreferences.mangaExtensionRepos().get().flatMap {
+                getExtensions(it)
             }
 
             // Sanity check - a small number of extensions probably means something broke

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/api/MangaExtensionApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/api/MangaExtensionApi.kt
@@ -36,9 +36,7 @@ internal class MangaExtensionApi {
 
     suspend fun findExtensions(): List<MangaExtension.Available> {
         return withIOContext {
-            val extensions = sourcePreferences.mangaExtensionRepos().get().flatMap {
-                getExtensions(it)
-            }
+            val extensions = sourcePreferences.mangaExtensionRepos().get().flatMap { getExtensions(it) }
 
             // Sanity check - a small number of extensions probably means something broke
             // with the repo generator


### PR DESCRIPTION
If the support channel in discord is anything to go by, having this repo added as default just leads to people who don't know anything about self-hosting attempting to use these extensions, which they shouldn't. Besides, the extensions in the repo are being updated maintained elsewhere so even if you are using these extensions, using them from this repo doesn't make much sense