### PR TITLE
Fix enhanced tracking for jellyfin

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/jellyfin/Jellyfin.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/jellyfin/Jellyfin.kt
@@ -12,7 +12,6 @@ import eu.kanade.tachiyomi.data.track.model.AnimeTrackSearch
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import okhttp3.Dns
-import okhttp3.OkHttpClient
 import tachiyomi.domain.entries.anime.model.Anime
 import tachiyomi.i18n.MR
 import tachiyomi.domain.track.anime.model.AnimeTrack as DomainTrack
@@ -25,11 +24,12 @@ class Jellyfin(id: Long) : BaseTracker(id, "Jellyfin"), EnhancedAnimeTracker, An
         const val COMPLETED = 3L
     }
 
-    override val client: OkHttpClient =
+    override val client by lazy {
         networkService.client.newBuilder()
             .addInterceptor(JellyfinInterceptor())
             .dns(Dns.SYSTEM) // don't use DNS over HTTPS as it breaks IP addressing
             .build()
+    }
 
     val api by lazy { JellyfinApi(id, client) }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/jellyfin/JellyfinApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/jellyfin/JellyfinApi.kt
@@ -16,6 +16,7 @@ import tachiyomi.core.common.util.system.logcat
 import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
 import kotlin.math.abs
 
 class JellyfinApi(
@@ -64,7 +65,6 @@ class JellyfinApi(
     }
 
     private fun getEpisodesUrl(url: HttpUrl): HttpUrl {
-        val apiKey = url.queryParameter("api_key")!!
         val fragment = url.fragment!!
 
         return url.newBuilder().apply {
@@ -75,7 +75,6 @@ class JellyfinApi(
             addPathSegment("Shows")
             addPathSegment(fragment.split(",").last())
             addPathSegment("Episodes")
-            addQueryParameter("api_key", apiKey)
             addQueryParameter("seasonId", url.pathSegments.last())
             addQueryParameter("userId", url.pathSegments[1])
             addQueryParameter("Fields", "Overview,MediaSources")
@@ -139,7 +138,7 @@ class JellyfinApi(
         }
 
         if (itemId != null) {
-            val time = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(Date())
+            val time = DATE_FORMATTER.format(Date())
             val postUrl = httpUrl.newBuilder().apply {
                 fragment(null)
                 removePathSegment(3)
@@ -159,5 +158,9 @@ class JellyfinApi(
 
     private fun Long.equalsTo(other: Double): Boolean {
         return abs(this - other) < 0.001
+    }
+
+    companion object {
+        private val DATE_FORMATTER = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/jellyfin/JellyfinInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/jellyfin/JellyfinInterceptor.kt
@@ -1,10 +1,20 @@
 package eu.kanade.tachiyomi.data.track.jellyfin
 
 import eu.kanade.tachiyomi.BuildConfig
+import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import okhttp3.Interceptor
 import okhttp3.Response
+import tachiyomi.domain.source.anime.service.AnimeSourceManager
+import uy.kohesive.injekt.injectLazy
+import java.io.IOException
+import java.security.MessageDigest
 
 class JellyfinInterceptor : Interceptor {
+
+    private val sourceManager: AnimeSourceManager by injectLazy()
+
+    private val apiKeys = mutableMapOf<String, String>()
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
 
@@ -13,6 +23,51 @@ class JellyfinInterceptor : Interceptor {
             .header("User-Agent", "Aniyomi v${BuildConfig.VERSION_NAME} (${BuildConfig.APPLICATION_ID})")
             .build()
 
-        return chain.proceed(uaRequest)
+        // Check api keys
+        if (originalRequest.url.queryParameter("api_key") != null) {
+            return chain.proceed(uaRequest)
+        }
+
+        val userId = originalRequest.url.queryParameter("userId") ?: originalRequest.url.pathSegments[1]
+        val apiKey = apiKeys[userId] ?: getApiKey(userId)?.also { apiKeys[userId] = it }
+            ?: throw IOException("Please log in through the extension")
+
+        val authUrl = originalRequest.url.newBuilder()
+            .addQueryParameter("api_key", apiKey)
+            .build()
+
+        val authRequest = uaRequest.newBuilder().url(authUrl).build()
+        return chain.proceed(authRequest)
+    }
+
+    @Suppress("MagicNumber")
+    private fun getId(suffix: Int): Long {
+        val key = "jellyfin" + (if (suffix == 1) "" else " ($suffix)") + "/all/$JELLYFIN_VERSION_ID"
+        val bytes = MessageDigest.getInstance("MD5").digest(key.toByteArray())
+        return (0..7).map { bytes[it].toLong() and 0xff shl 8 * (7 - it) }
+            .reduce(Long::or) and Long.MAX_VALUE
+    }
+
+    private fun getApiKey(userId: String): String? {
+        for (i in 1..MAX_JELLYFIN_SOURCES) {
+            val sourceId = getId(i)
+            val preferences = (sourceManager.get(sourceId) as ConfigurableAnimeSource).getSourcePreferences()
+            val sourceUserId = preferences.getString("user_id", "")
+
+            if (sourceUserId.isNullOrEmpty()) {
+                continue // Source not configured
+            }
+
+            if (sourceUserId == userId) {
+                return preferences.getString("api_key", "")
+            }
+        }
+
+        return null
+    }
+
+    companion object {
+        private const val JELLYFIN_VERSION_ID = 1
+        private const val MAX_JELLYFIN_SOURCES = 10
     }
 }


### PR DESCRIPTION
I broke enhanced tracking by removing the api key from the url, so now it will go through the source's preferences instead. Old urls will still work