### PR TITLE
[skip ci] feat(github): Remove mentions of official ext repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ⚠️ Anime extension/source issue
-    url: https://github.com/aniyomiorg/aniyomi-extensions/issues/new/choose
-    about: Issues and requests for official extensions and sources should be opened in the aniyomi-extensions repository instead
-  - name: 📦 Aniyomi extensions
-    url: https://aniyomi.org/extensions/
-    about: Anime extensions and sources
   - name: 🧑‍💻 Aniyomi help discord
     url: https://discord.gg/F32UjdJZrR
     about: Common questions are answered here

--- a/.github/ISSUE_TEMPLATE/report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/report_issue.yml
@@ -93,9 +93,7 @@ body:
           required: true
         - label: I have written a short but informative title.
           required: true
-        - label: If this is an issue with an official anime extension, I should be opening an issue in the [extensions repository](https://github.com/aniyomiorg/aniyomi-extensions/issues/new/choose).
-          required: true
-        - label: If this is an issue with a manga extension, report it to the manga source extension project you added it from.
+        - label: If this is an issue with an extension, I should be opening an issue in the extension's repository.
           required: true
         - label: I have gone through the [FAQ](https://aniyomi.org/docs/faq/general) and [troubleshooting guide](https://aniyomi.org/docs/guides/troubleshooting/).
           required: true

--- a/.github/ISSUE_TEMPLATE/request_feature.yml
+++ b/.github/ISSUE_TEMPLATE/request_feature.yml
@@ -30,7 +30,7 @@ body:
           required: true
         - label: I have written a short but informative title.
           required: true
-        - label: If this is an issue with an official extension, I should be opening an issue in the [extensions repository](https://github.com/aniyomiorg/aniyomi-extensions/issues/new/choose).
+        - label: If this is a request regarding an extension, I should be opening an issue in the extension's repository.
           required: true
         - label: I have updated the app to version **[0.15.3.0](https://github.com/aniyomiorg/aniyomi/releases/latest)**.
           required: true

--- a/README.md
+++ b/README.md
@@ -51,9 +51,6 @@ Please make sure to read the full guidelines. Your issue may be closed without w
 * Write a detailed issue, explaining what it should do or how. Avoid writing just "like X app does"
 * Include screenshot (if needed)
 
-Source requests should be created at https://github.com/aniyomiorg/aniyomi-extensions, they do not belong in this repository.
-</details>
-
 <details><summary>Contributing</summary>
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
Removes mentions of official extension repositories in issue templates and the readme.md.

The extension repo itself will be removed in my mihon merge, so there's no point in removing it now.