### PR TITLE
fix: hidden categories got reset after delete/reorder

### DIFF
--- a/data/src/main/java/tachiyomi/data/category/anime/AnimeCategoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/category/anime/AnimeCategoryRepositoryImpl.kt
@@ -84,7 +84,7 @@ class AnimeCategoryRepositoryImpl(
             name = update.name,
             order = update.order,
             flags = update.flags,
-            hidden = if (update.hidden == true) 1L else 0L,
+            hidden = update.hidden?.let { if (it) 1L else 0L },
             categoryId = update.id,
         )
     }

--- a/data/src/main/java/tachiyomi/data/category/manga/MangaCategoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/category/manga/MangaCategoryRepositoryImpl.kt
@@ -84,7 +84,7 @@ class MangaCategoryRepositoryImpl(
             name = update.name,
             order = update.order,
             flags = update.flags,
-            hidden = if (update.hidden == true) 1L else 0L,
+            hidden = update.hidden?.let { if (it) 1L else 0L },
             categoryId = update.id,
         )
     }


### PR DESCRIPTION
categories' hidden flag got reset after deleting/reordering.

## Reproduce
1. Go to Settings/Categories screen
2. Hide any category
3. Try deleting any other category or Try reordering categories

## Expectation
The hidden categories should stay hidden

## Actually
All categories become un-hidden