### PR TITLE
fix: History date header duplication

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/components/DateText.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/DateText.kt
@@ -27,6 +27,7 @@ fun relativeDateText(
     )
 }
 
+// For use in chapter/episode release time
 @Composable
 fun relativeDateTimeText(
     dateEpochMillis: Long,
@@ -58,6 +59,7 @@ fun relativeDateText(
         ?: stringResource(MR.strings.not_applicable)
 }
 
+// For use in chapter/episode release time
 @Composable
 fun relativeDateTimeText(
     localDateTime: LocalDateTime?,

--- a/app/src/main/java/eu/kanade/presentation/history/anime/AnimeHistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/anime/AnimeHistoryScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import eu.kanade.presentation.components.relativeDateTimeText
+import eu.kanade.presentation.components.relativeDateText
 import eu.kanade.presentation.history.anime.components.AnimeHistoryItem
 import eu.kanade.presentation.theme.TachiyomiPreviewTheme
 import eu.kanade.presentation.util.animateItemFastScroll
@@ -21,7 +21,7 @@ import tachiyomi.presentation.core.components.ListGroupHeader
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.LoadingScreen
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 @Composable
 fun AnimeHistoryScreen(
@@ -86,7 +86,7 @@ private fun AnimeHistoryScreenContent(
                 is AnimeHistoryUiModel.Header -> {
                     ListGroupHeader(
                         modifier = Modifier.animateItemFastScroll(),
-                        text = relativeDateTimeText(item.date),
+                        text = relativeDateText(item.date),
                     )
                 }
                 is AnimeHistoryUiModel.Item -> {
@@ -105,7 +105,7 @@ private fun AnimeHistoryScreenContent(
 }
 
 sealed interface AnimeHistoryUiModel {
-    data class Header(val date: LocalDateTime) : AnimeHistoryUiModel
+    data class Header(val date: LocalDate) : AnimeHistoryUiModel
     data class Item(val item: AnimeHistoryWithRelations) : AnimeHistoryUiModel
 }
 

--- a/app/src/main/java/eu/kanade/presentation/history/anime/AnimeHistoryScreenModelStateProvider.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/anime/AnimeHistoryScreenModelStateProvider.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.ui.history.anime.AnimeHistoryScreenModel
 import tachiyomi.domain.entries.anime.model.AnimeCover
 import tachiyomi.domain.history.anime.model.AnimeHistoryWithRelations
 import java.time.Instant
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import java.util.Date
 import kotlin.random.Random
@@ -72,10 +72,10 @@ class AnimeHistoryScreenModelStateProvider : PreviewParameterProvider<AnimeHisto
     private object HistoryUiModelExamples {
         val headerToday = header()
         val headerTomorrow =
-            AnimeHistoryUiModel.Header(LocalDateTime.now().plusDays(1))
+            AnimeHistoryUiModel.Header(LocalDate.now().plusDays(1))
 
         fun header(instantBuilder: (Instant) -> Instant = { it }) =
-            AnimeHistoryUiModel.Header(LocalDateTime.from(instantBuilder(Instant.now())))
+            AnimeHistoryUiModel.Header(LocalDate.from(instantBuilder(Instant.now())))
 
         fun items() = sequence {
             var count = 1

--- a/app/src/main/java/eu/kanade/presentation/history/manga/MangaHistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/manga/MangaHistoryScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import eu.kanade.presentation.components.relativeDateTimeText
+import eu.kanade.presentation.components.relativeDateText
 import eu.kanade.presentation.history.manga.components.MangaHistoryItem
 import eu.kanade.presentation.theme.TachiyomiPreviewTheme
 import eu.kanade.presentation.util.animateItemFastScroll
@@ -21,7 +21,7 @@ import tachiyomi.presentation.core.components.ListGroupHeader
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.LoadingScreen
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 @Composable
 fun MangaHistoryScreen(
@@ -86,7 +86,7 @@ private fun MangaHistoryScreenContent(
                 is MangaHistoryUiModel.Header -> {
                     ListGroupHeader(
                         modifier = Modifier.animateItemFastScroll(),
-                        text = relativeDateTimeText(item.date),
+                        text = relativeDateText(item.date),
                     )
                 }
                 is MangaHistoryUiModel.Item -> {
@@ -105,7 +105,7 @@ private fun MangaHistoryScreenContent(
 }
 
 sealed interface MangaHistoryUiModel {
-    data class Header(val date: LocalDateTime) : MangaHistoryUiModel
+    data class Header(val date: LocalDate) : MangaHistoryUiModel
     data class Item(val item: MangaHistoryWithRelations) : MangaHistoryUiModel
 }
 

--- a/app/src/main/java/eu/kanade/presentation/history/manga/MangaHistoryScreenModelStateProvider.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/manga/MangaHistoryScreenModelStateProvider.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.ui.history.manga.MangaHistoryScreenModel
 import tachiyomi.domain.entries.manga.model.MangaCover
 import tachiyomi.domain.history.manga.model.MangaHistoryWithRelations
 import java.time.Instant
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import java.util.Date
 import kotlin.random.Random
@@ -72,10 +72,10 @@ class MangaHistoryScreenModelStateProvider : PreviewParameterProvider<MangaHisto
     private object HistoryUiModelExamples {
         val headerToday = header()
         val headerTomorrow =
-            MangaHistoryUiModel.Header(LocalDateTime.now().plusDays(1))
+            MangaHistoryUiModel.Header(LocalDate.now().plusDays(1))
 
         fun header(instantBuilder: (Instant) -> Instant = { it }) =
-            MangaHistoryUiModel.Header(LocalDateTime.from(instantBuilder(Instant.now())))
+            MangaHistoryUiModel.Header(LocalDate.from(instantBuilder(Instant.now())))
 
         fun items() = sequence {
             var count = 1

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/anime/AnimeHistoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/anime/AnimeHistoryScreenModel.kt
@@ -5,7 +5,7 @@ import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.core.util.insertSeparators
 import eu.kanade.presentation.history.anime.AnimeHistoryUiModel
-import eu.kanade.tachiyomi.util.lang.toLocalDateTime
+import eu.kanade.tachiyomi.util.lang.toLocalDate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -69,8 +69,8 @@ class AnimeHistoryScreenModel(
     private fun List<AnimeHistoryWithRelations>.toAnimeHistoryUiModels(): List<AnimeHistoryUiModel> {
         return map { AnimeHistoryUiModel.Item(it) }
             .insertSeparators { before, after ->
-                val beforeDate = before?.item?.seenAt?.time?.toLocalDateTime()
-                val afterDate = after?.item?.seenAt?.time?.toLocalDateTime()
+                val beforeDate = before?.item?.seenAt?.time?.toLocalDate()
+                val afterDate = after?.item?.seenAt?.time?.toLocalDate()
                 when {
                     beforeDate != afterDate && afterDate != null -> AnimeHistoryUiModel.Header(afterDate)
                     // Return null to avoid adding a separator between two items.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/manga/MangaHistoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/manga/MangaHistoryScreenModel.kt
@@ -5,7 +5,7 @@ import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.core.util.insertSeparators
 import eu.kanade.presentation.history.manga.MangaHistoryUiModel
-import eu.kanade.tachiyomi.util.lang.toLocalDateTime
+import eu.kanade.tachiyomi.util.lang.toLocalDate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -69,8 +69,8 @@ class MangaHistoryScreenModel(
     private fun List<MangaHistoryWithRelations>.toHistoryUiModels(): List<MangaHistoryUiModel> {
         return map { MangaHistoryUiModel.Item(it) }
             .insertSeparators { before, after ->
-                val beforeDate = before?.item?.readAt?.time?.toLocalDateTime()
-                val afterDate = after?.item?.readAt?.time?.toLocalDateTime()
+                val beforeDate = before?.item?.readAt?.time?.toLocalDate()
+                val afterDate = after?.item?.readAt?.time?.toLocalDate()
                 when {
                     beforeDate != afterDate && afterDate != null -> MangaHistoryUiModel.Header(afterDate)
                     // Return null to avoid adding a separator between two items.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/dialogs/EpisodeListDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/dialogs/EpisodeListDialog.kt
@@ -43,7 +43,7 @@ import tachiyomi.presentation.core.components.material.DISABLED_ALPHA
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 import java.time.Instant
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
@@ -94,7 +94,7 @@ fun EpisodeListDialog(
                     val date = episode.date_upload
                         .takeIf { it > 0L }
                         ?.let {
-                            LocalDateTime.ofInstant(
+                            LocalDate.ofInstant(
                                 Instant.ofEpochMilli(it),
                                 ZoneId.systemDefault(),
                             ).toRelativeString(

--- a/app/src/main/java/eu/kanade/tachiyomi/util/lang/DateExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/lang/DateExtensions.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.util.lang
 
 import android.content.Context
-import eu.kanade.tachiyomi.R
 import tachiyomi.core.common.i18n.pluralStringResource
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.i18n.MR
@@ -40,16 +39,8 @@ fun Long.toLocalDate(): LocalDate {
     return LocalDate.ofInstant(Instant.ofEpochMilli(this), ZoneId.systemDefault())
 }
 
-fun Long.toLocalDateTime(): LocalDateTime {
-    return LocalDateTime.ofInstant(Instant.ofEpochMilli(this), ZoneId.systemDefault())
-}
-
 fun Instant.toLocalDate(zoneId: ZoneId = ZoneId.systemDefault()): LocalDate {
     return LocalDate.ofInstant(this, zoneId)
-}
-
-fun Instant.toLocalDateTime(zoneId: ZoneId = ZoneId.systemDefault()): LocalDateTime {
-    return LocalDateTime.ofInstant(this, zoneId)
 }
 
 fun LocalDate.toRelativeString(
@@ -70,8 +61,8 @@ fun LocalDate.toRelativeString(
             difference.toInt().absoluteValue,
         )
         difference < 1 -> context.stringResource(MR.strings.relative_time_today)
-        difference < 7 -> context.resources.getQuantityString(
-            R.plurals.relative_time,
+        difference < 7 -> context.pluralStringResource(
+            MR.plurals.relative_time,
             difference.toInt(),
             difference.toInt(),
         )
@@ -79,6 +70,7 @@ fun LocalDate.toRelativeString(
     }
 }
 
+// For use in chapter/episode release time
 fun LocalDateTime.toRelativeString(
     context: Context,
     relative: Boolean = true,
@@ -128,8 +120,8 @@ fun LocalDateTime.toRelativeString(
                 )
             }
         }
-        timeDifference < 7 -> context.resources.getQuantityString(
-            R.plurals.relative_time,
+        timeDifference < 7 -> context.pluralStringResource(
+            MR.plurals.relative_time,
             dateDifference.toInt(),
             dateDifference.toInt(),
         )


### PR DESCRIPTION
Changes 
---
- Fixed misuse of LocalDateTime instead of LocalDate within History UI
- History no longer has continuous duplication of date headers
- Does ***not*** affect the "$ Hours Ago" and "$ Minutes Ago" text for chapter/episode releases