### PR TITLE
Fix gesture seeking not seeking to start and end

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/GestureHandler.kt
@@ -206,7 +206,7 @@ fun GestureHandler(
                                     .coerceIn(0 - startingPosition, (duration - startingPosition).toInt()),
                             )
                         }
-                        viewModel.seekTo(it, preciseSeeking)
+                        viewModel.seekTo(it.coerceIn(0, duration.toInt()), preciseSeeking)
                     }
 
                     if (showSeekbar) viewModel.showSeekBar()


### PR DESCRIPTION
Fixes gesture seeking not working when dragging too fast to the start or end of a video