### PR TITLE
Fix episode being marked as seen at start

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -1009,6 +1009,7 @@ class PlayerViewModel @JvmOverloads constructor(
         if (isLoadingEpisode.value) return
         val currentEp = currentEpisode.value ?: return
         if (episodeId == -1L) return
+        if (duration == 0) return
 
         val seconds = position * 1000L
         val totalSeconds = duration * 1000L


### PR DESCRIPTION
Sometimes `onSecondReached` is called before `duration.update{...}`, which marks the episode as seen when just opening the video