### PR TITLE
feat(ui): size slider for the List Display Mode (Closes #1894)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/entries/anime/components/BaseAnimeListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/anime/components/BaseAnimeListItem.kt
@@ -31,8 +31,8 @@ fun BaseAnimeListItem(
     Row(
         modifier = modifier
             .clickable(onClick = onClickItem)
-            .height(56.dp)
-            .padding(horizontal = MaterialTheme.padding.medium),
+            .height(76.dp)
+            .padding(horizontal = MaterialTheme.padding.medium, vertical = 3.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         cover()
@@ -42,9 +42,8 @@ fun BaseAnimeListItem(
 }
 
 private val defaultCover: @Composable RowScope.(Anime, () -> Unit) -> Unit = { anime, onClick ->
-    ItemCover.Square(
+    ItemCover.Book(
         modifier = Modifier
-            .padding(vertical = MaterialTheme.padding.small)
             .fillMaxHeight(),
         data = anime,
         onClick = onClick,
@@ -58,7 +57,6 @@ private val defaultContent: @Composable RowScope.(Anime) -> Unit = {
             modifier = Modifier
                 .padding(start = MaterialTheme.padding.medium),
             overflow = TextOverflow.Ellipsis,
-            maxLines = 1,
             style = MaterialTheme.typography.bodyMedium,
         )
     }

--- a/app/src/main/java/eu/kanade/presentation/entries/manga/components/BaseMangaListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/manga/components/BaseMangaListItem.kt
@@ -31,8 +31,8 @@ fun BaseMangaListItem(
     Row(
         modifier = modifier
             .clickable(onClick = onClickItem)
-            .height(56.dp)
-            .padding(horizontal = MaterialTheme.padding.medium),
+            .height(76.dp)
+            .padding(horizontal = MaterialTheme.padding.medium, vertical = 3.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         cover()
@@ -42,9 +42,8 @@ fun BaseMangaListItem(
 }
 
 private val defaultCover: @Composable RowScope.(Manga, () -> Unit) -> Unit = { manga, onClick ->
-    ItemCover.Square(
+    ItemCover.Book(
         modifier = Modifier
-            .padding(vertical = MaterialTheme.padding.small)
             .fillMaxHeight(),
         data = manga,
         onClick = onClick,
@@ -58,7 +57,6 @@ private val defaultContent: @Composable RowScope.(Manga) -> Unit = {
             modifier = Modifier
                 .padding(start = MaterialTheme.padding.medium),
             overflow = TextOverflow.Ellipsis,
-            maxLines = 1,
             style = MaterialTheme.typography.bodyMedium,
         )
     }

--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryList.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryList.kt
@@ -22,6 +22,8 @@ import tachiyomi.presentation.core.util.plus
 @Composable
 internal fun AnimeLibraryList(
     items: List<AnimeLibraryItem>,
+    entries: Int,
+    containerHeight: Int,
     contentPadding: PaddingValues,
     selection: List<LibraryAnime>,
     onClick: (LibraryAnime) -> Unit,
@@ -74,6 +76,8 @@ internal fun AnimeLibraryList(
                 } else {
                     null
                 },
+                entries = entries,
+                containerHeight = containerHeight,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryPager.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryPager.kt
@@ -14,8 +14,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import eu.kanade.core.preference.PreferenceMutableState
@@ -42,8 +44,13 @@ fun AnimeLibraryPager(
     onLongClickAnime: (LibraryAnime) -> Unit,
     onClickContinueWatching: ((LibraryAnime) -> Unit)?,
 ) {
+    var containerHeight by remember { mutableIntStateOf(0) }
     HorizontalPager(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .onGloballyPositioned { layoutCoordinates ->
+                containerHeight = layoutCoordinates.size.height
+            },
         state = state,
         verticalAlignment = Alignment.Top,
     ) { page ->
@@ -64,19 +71,16 @@ fun AnimeLibraryPager(
         }
 
         val displayMode by getDisplayMode(page)
-        val columns by if (displayMode != LibraryDisplayMode.List) {
-            val configuration = LocalConfiguration.current
-            val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-
-            remember(isLandscape) { getColumnsForOrientation(isLandscape) }
-        } else {
-            remember { mutableIntStateOf(0) }
-        }
+        val configuration = LocalConfiguration.current
+        val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        val columns by remember(isLandscape) { getColumnsForOrientation(isLandscape) }
 
         when (displayMode) {
             LibraryDisplayMode.List -> {
                 AnimeLibraryList(
                     items = library,
+                    entries = columns,
+                    containerHeight = containerHeight,
                     contentPadding = contentPadding,
                     selection = selectedAnime,
                     onClick = onClickAnime,

--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibrarySettingsDialog.kt
@@ -36,6 +36,7 @@ import tachiyomi.presentation.core.components.SettingsChipRow
 import tachiyomi.presentation.core.components.SliderItem
 import tachiyomi.presentation.core.components.SortItem
 import tachiyomi.presentation.core.components.TriStateItem
+import tachiyomi.presentation.core.i18n.pluralStringResource
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 
@@ -248,17 +249,29 @@ private fun ColumnScope.DisplayPage(
         }
     }
 
-    if (displayMode != LibraryDisplayMode.List) {
-        val configuration = LocalConfiguration.current
-        val columnPreference = remember {
-            if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                screenModel.libraryPreferences.animeLandscapeColumns()
-            } else {
-                screenModel.libraryPreferences.animePortraitColumns()
-            }
+    val configuration = LocalConfiguration.current
+    val columnPreference = remember {
+        if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            screenModel.libraryPreferences.animeLandscapeColumns()
+        } else {
+            screenModel.libraryPreferences.animePortraitColumns()
         }
+    }
 
-        val columns by columnPreference.collectAsState()
+    val columns by columnPreference.collectAsState()
+    if (displayMode == LibraryDisplayMode.List) {
+        SliderItem(
+            label = stringResource(MR.strings.pref_library_rows),
+            max = 10,
+            value = columns,
+            valueText = if (columns > 0) {
+                pluralStringResource(MR.plurals.pref_library_entries_in_column, columns, columns,)
+            } else {
+                stringResource(MR.strings.label_default)
+            },
+            onChange = columnPreference::set,
+        )
+    } else {
         SliderItem(
             label = stringResource(MR.strings.pref_library_columns),
             max = 10,

--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibrarySettingsDialog.kt
@@ -265,7 +265,7 @@ private fun ColumnScope.DisplayPage(
             max = 10,
             value = columns,
             valueText = if (columns > 0) {
-                pluralStringResource(MR.plurals.pref_library_entries_in_column, columns, columns,)
+                pluralStringResource(MR.plurals.pref_library_entries_in_column, columns, columns)
             } else {
                 stringResource(MR.strings.label_default)
             },

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonEntryItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonEntryItem.kt
@@ -342,16 +342,22 @@ fun EntryListItem(
     entries: Int = -1,
     containerHeight: Int = 0,
 ) {
-    val density =  LocalDensity.current
+    val density = LocalDensity.current
     Row(
         modifier = Modifier
             .selectedBackground(isSelected)
             .height(
                 when (entries) {
-                    -1 ->   { 76.dp }
-                     0 ->   { with(density){(containerHeight / 7).toDp()} - (3/7).dp }
-                    else -> { with(density){(containerHeight / entries).toDp()} - (3/entries).dp }
-                }
+                    -1 -> {
+                        76.dp
+                    }
+                    0 -> {
+                        with(density) { (containerHeight / 7).toDp() } - (3 / 7).dp
+                    }
+                    else -> {
+                        with(density) { (containerHeight / entries).toDp() } - (3 / entries).dp
+                    }
+                },
             )
             .combinedClickable(
                 onClick = onClick,
@@ -371,7 +377,7 @@ fun EntryListItem(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .weight(1f),
-            //maxLines = 2,
+            // maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             style = MaterialTheme.typography.bodyMedium,
         )

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonEntryItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonEntryItem.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -338,19 +339,28 @@ fun EntryListItem(
     onClick: () -> Unit,
     badge: @Composable (RowScope.() -> Unit),
     onClickContinueViewing: (() -> Unit)? = null,
+    entries: Int = -1,
+    containerHeight: Int = 0,
 ) {
+    val density =  LocalDensity.current
     Row(
         modifier = Modifier
             .selectedBackground(isSelected)
-            .height(56.dp)
+            .height(
+                when (entries) {
+                    -1 ->   { 76.dp }
+                     0 ->   { with(density){(containerHeight / 7).toDp()} - (3/7).dp }
+                    else -> { with(density){(containerHeight / entries).toDp()} - (3/entries).dp }
+                }
+            )
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = onLongClick,
             )
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = 16.dp, vertical = 3.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        ItemCover.Square(
+        ItemCover.Book(
             modifier = Modifier
                 .fillMaxHeight()
                 .alpha(coverAlpha),
@@ -361,7 +371,7 @@ fun EntryListItem(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .weight(1f),
-            maxLines = 2,
+            //maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             style = MaterialTheme.typography.bodyMedium,
         )

--- a/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibraryList.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibraryList.kt
@@ -22,6 +22,8 @@ import tachiyomi.presentation.core.util.plus
 @Composable
 internal fun MangaLibraryList(
     items: List<MangaLibraryItem>,
+    entries: Int,
+    containerHeight: Int,
     contentPadding: PaddingValues,
     selection: List<LibraryManga>,
     onClick: (LibraryManga) -> Unit,
@@ -74,6 +76,8 @@ internal fun MangaLibraryList(
                 } else {
                     null
                 },
+                entries = entries,
+                containerHeight = containerHeight,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibraryPager.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibraryPager.kt
@@ -14,8 +14,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import eu.kanade.core.preference.PreferenceMutableState
@@ -42,8 +44,13 @@ fun MangaLibraryPager(
     onLongClickManga: (LibraryManga) -> Unit,
     onClickContinueReading: ((LibraryManga) -> Unit)?,
 ) {
+    var containerHeight by remember { mutableIntStateOf(0) }
     HorizontalPager(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .onGloballyPositioned { layoutCoordinates ->
+                containerHeight = layoutCoordinates.size.height
+            },
         state = state,
         verticalAlignment = Alignment.Top,
     ) { page ->
@@ -64,19 +71,16 @@ fun MangaLibraryPager(
         }
 
         val displayMode by getDisplayMode(page)
-        val columns by if (displayMode != LibraryDisplayMode.List) {
-            val configuration = LocalConfiguration.current
-            val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-
-            remember(isLandscape) { getColumnsForOrientation(isLandscape) }
-        } else {
-            remember { mutableIntStateOf(0) }
-        }
+        val configuration = LocalConfiguration.current
+        val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        val columns by remember(isLandscape) { getColumnsForOrientation(isLandscape) }
 
         when (displayMode) {
             LibraryDisplayMode.List -> {
                 MangaLibraryList(
                     items = library,
+                    entries = columns,
+                    containerHeight = containerHeight,
                     contentPadding = contentPadding,
                     selection = selectedManga,
                     onClick = onClickManga,

--- a/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibrarySettingsDialog.kt
@@ -36,6 +36,7 @@ import tachiyomi.presentation.core.components.SettingsChipRow
 import tachiyomi.presentation.core.components.SliderItem
 import tachiyomi.presentation.core.components.SortItem
 import tachiyomi.presentation.core.components.TriStateItem
+import tachiyomi.presentation.core.i18n.pluralStringResource
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 
@@ -247,23 +248,35 @@ private fun ColumnScope.DisplayPage(
         }
     }
 
-    if (displayMode != LibraryDisplayMode.List) {
-        val configuration = LocalConfiguration.current
-        val columnPreference = remember {
-            if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                screenModel.libraryPreferences.mangaLandscapeColumns()
-            } else {
-                screenModel.libraryPreferences.mangaPortraitColumns()
-            }
+    val configuration = LocalConfiguration.current
+    val columnPreference = remember {
+        if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            screenModel.libraryPreferences.mangaLandscapeColumns()
+        } else {
+            screenModel.libraryPreferences.mangaPortraitColumns()
         }
+    }
 
-        val columns by columnPreference.collectAsState()
+    val columns by columnPreference.collectAsState()
+    if (displayMode == LibraryDisplayMode.List) {
+        SliderItem(
+            label = stringResource(MR.strings.pref_library_rows),
+            max = 10,
+            value = columns,
+            valueText = if (columns > 0) {
+                pluralStringResource(MR.plurals.pref_library_entries_in_column, columns, columns,)
+            } else {
+                stringResource(MR.strings.label_default)
+            },
+            onChange = columnPreference::set,
+        )
+    } else {
         SliderItem(
             label = stringResource(MR.strings.pref_library_columns),
             max = 10,
             value = columns,
             valueText = if (columns > 0) {
-                stringResource(MR.strings.pref_library_columns_per_row, columns)
+                stringResource(MR.strings.pref_library_columns_per_row, columns,)
             } else {
                 stringResource(MR.strings.label_default)
             },

--- a/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibrarySettingsDialog.kt
@@ -264,7 +264,7 @@ private fun ColumnScope.DisplayPage(
             max = 10,
             value = columns,
             valueText = if (columns > 0) {
-                pluralStringResource(MR.plurals.pref_library_entries_in_column, columns, columns,)
+                pluralStringResource(MR.plurals.pref_library_entries_in_column, columns, columns)
             } else {
                 stringResource(MR.strings.label_default)
             },
@@ -276,7 +276,7 @@ private fun ColumnScope.DisplayPage(
             max = 10,
             value = columns,
             valueText = if (columns > 0) {
-                stringResource(MR.strings.pref_library_columns_per_row, columns,)
+                stringResource(MR.strings.pref_library_columns_per_row, columns)
             } else {
                 stringResource(MR.strings.label_default)
             },

--- a/i18n/src/commonMain/moko-resources/base/plurals.xml
+++ b/i18n/src/commonMain/moko-resources/base/plurals.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<plurals name="pref_library_entries_in_column">
+		<item quantity="one">1 entry</item>
+		<item quantity="other">%d entries</item>
+	</plurals>
     <plurals name="lock_after_mins">
         <item quantity="one">After %1$s minute</item>
         <item quantity="other">After %1$s minutes</item>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -540,6 +540,7 @@
     <string name="pref_category_display">Display</string>
     <string name="pref_library_columns">Grid size</string>
     <string name="pref_library_columns_per_row">%d per row</string>
+    <string name="pref_library_rows">List size</string>
     <string name="portrait">Portrait</string>
     <string name="landscape">Landscape</string>
     <string name="pref_category_library_update">Global update</string>


### PR DESCRIPTION
Added a size slider for the List Display Mode. It uses the same size variable as Grids do to determine size. However, the size of the List gets interpreted not as \<number\> of columns per row, but rather as \<number\> of entries of the list visible on the screen at once ([images 1](https://github.com/user-attachments/assets/ba5e0599-3c97-4184-b3eb-8170022ed518) [and 2](https://github.com/user-attachments/assets/dc641ef7-96e9-4287-982e-e339782aba46)). The default value is set to be 7 for the List. 

The style of the List was changed: the cover is of Book resolution to match the Grids and for better visibility ([image 4](https://github.com/user-attachments/assets/d3cc87ab-1208-4f8f-870b-6af179cc9ec3)).

Other two lists ([browse list](https://github.com/user-attachments/assets/2bdb5784-f7a6-4442-a385-6444f7f3bb12) and [migration list](https://github.com/user-attachments/assets/8b9b707c-6a06-4535-b18f-74a8b3609cf5)) don't have editable size, but neither do browse grids, so it's fine. Instead they now have a predetermined size of 76.dp (was 56.dp previously) and are visually changed to match the library list style.

The size slider also has two additional text fields added, which would need translation (though i assume that's automated).

The max line restriction for titles was removed, allowing for longer names to be fully visible, given the List is set to a big enough size ([image 6](https://github.com/user-attachments/assets/8b9b707c-6a06-4535-b18f-74a8b3609cf5)).

closes #1894 

### Showcase
| ![Screenshot_20250128-175245_Aniyomi](https://github.com/user-attachments/assets/ba5e0599-3c97-4184-b3eb-8170022ed518) |  ![Screenshot_20250128-175239_Aniyomi](https://github.com/user-attachments/assets/dc641ef7-96e9-4287-982e-e339782aba46) | ![Screenshot_20250128-175513_Aniyomi](https://github.com/user-attachments/assets/614954ad-7c8e-459f-bdf4-af24efb20519) | 
| --- | --- | --- | 
| ![Screenshot_20250128-175315_Aniyomi](https://github.com/user-attachments/assets/d3cc87ab-1208-4f8f-870b-6af179cc9ec3) | ![Screenshot_20250128-175357_Aniyomi](https://github.com/user-attachments/assets/2bdb5784-f7a6-4442-a385-6444f7f3bb12) | ![Screenshot_20250128-175326_Aniyomi](https://github.com/user-attachments/assets/8b9b707c-6a06-4535-b18f-74a8b3609cf5) |


![Screenshot_20250128-181306_Aniyomi](https://github.com/user-attachments/assets/1cc458f1-d0fa-4550-86d8-aa74a50e16e0)
![Screenshot_20250128-181329_Aniyomi](https://github.com/user-attachments/assets/47f89810-9793-44ff-bfe9-8881b151f70f)





<!--
  Please include a summary

 of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
