### PR TITLE
fixup(ui): make the default list a set size and make browse list scale

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/anime/BrowseAnimeSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/anime/BrowseAnimeSourceScreen.kt
@@ -41,6 +41,8 @@ fun BrowseAnimeSourceContent(
     source: AnimeSource?,
     animeList: LazyPagingItems<StateFlow<Anime>>,
     columns: GridCells,
+    entries: Int = 0,
+    topBarHeight: Int = 0,
     displayMode: LibraryDisplayMode,
     snackbarHostState: SnackbarHostState,
     contentPadding: PaddingValues,
@@ -129,6 +131,8 @@ fun BrowseAnimeSourceContent(
         LibraryDisplayMode.List -> {
             BrowseAnimeSourceList(
                 animeList = animeList,
+                entries = entries,
+                topBarHeight = topBarHeight,
                 contentPadding = contentPadding,
                 onAnimeClick = onAnimeClick,
                 onAnimeLongClick = onAnimeLongClick,

--- a/app/src/main/java/eu/kanade/presentation/browse/anime/components/BrowseAnimeSourceList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/anime/components/BrowseAnimeSourceList.kt
@@ -5,6 +5,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
@@ -20,12 +25,19 @@ import tachiyomi.presentation.core.util.plus
 @Composable
 fun BrowseAnimeSourceList(
     animeList: LazyPagingItems<StateFlow<Anime>>,
+    entries: Int,
+    topBarHeight: Int,
     contentPadding: PaddingValues,
     onAnimeClick: (Anime) -> Unit,
     onAnimeLongClick: (Anime) -> Unit,
 ) {
+    var containerHeight by remember { mutableIntStateOf(0)}
     LazyColumn(
         contentPadding = contentPadding + PaddingValues(vertical = 8.dp),
+        modifier = Modifier
+            .onGloballyPositioned { layoutCoordinates ->
+            containerHeight = layoutCoordinates.size.height - topBarHeight
+        }
     ) {
         item {
             if (animeList.loadState.prepend is LoadState.Loading) {
@@ -39,6 +51,8 @@ fun BrowseAnimeSourceList(
                 anime = anime,
                 onClick = { onAnimeClick(anime) },
                 onLongClick = { onAnimeLongClick(anime) },
+                entries = entries,
+                containerHeight = containerHeight,
             )
         }
 
@@ -55,6 +69,8 @@ private fun BrowseAnimeSourceListItem(
     anime: Anime,
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = onClick,
+    entries: Int,
+    containerHeight: Int,
 ) {
     EntryListItem(
         title = anime.title,
@@ -71,5 +87,7 @@ private fun BrowseAnimeSourceListItem(
         },
         onLongClick = onLongClick,
         onClick = onClick,
+        entries = entries,
+        containerHeight = containerHeight,
     )
 }

--- a/app/src/main/java/eu/kanade/presentation/browse/anime/components/BrowseAnimeSourceList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/anime/components/BrowseAnimeSourceList.kt
@@ -31,13 +31,13 @@ fun BrowseAnimeSourceList(
     onAnimeClick: (Anime) -> Unit,
     onAnimeLongClick: (Anime) -> Unit,
 ) {
-    var containerHeight by remember { mutableIntStateOf(0)}
+    var containerHeight by remember { mutableIntStateOf(0) }
     LazyColumn(
         contentPadding = contentPadding + PaddingValues(vertical = 8.dp),
         modifier = Modifier
             .onGloballyPositioned { layoutCoordinates ->
-            containerHeight = layoutCoordinates.size.height - topBarHeight
-        }
+                containerHeight = layoutCoordinates.size.height - topBarHeight
+            },
     ) {
         item {
             if (animeList.loadState.prepend is LoadState.Loading) {

--- a/app/src/main/java/eu/kanade/presentation/browse/manga/BrowseMangaSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/manga/BrowseMangaSourceScreen.kt
@@ -41,6 +41,8 @@ fun BrowseSourceContent(
     source: MangaSource?,
     mangaList: LazyPagingItems<StateFlow<Manga>>,
     columns: GridCells,
+    entries: Int = 0,
+    topBarHeight: Int = 0,
     displayMode: LibraryDisplayMode,
     snackbarHostState: SnackbarHostState,
     contentPadding: PaddingValues,
@@ -129,6 +131,8 @@ fun BrowseSourceContent(
         LibraryDisplayMode.List -> {
             BrowseMangaSourceList(
                 mangaList = mangaList,
+                entries = entries,
+                topBarHeight = topBarHeight,
                 contentPadding = contentPadding,
                 onMangaClick = onMangaClick,
                 onMangaLongClick = onMangaLongClick,

--- a/app/src/main/java/eu/kanade/presentation/browse/manga/components/BrowseMangaSourceList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/manga/components/BrowseMangaSourceList.kt
@@ -5,6 +5,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
@@ -19,12 +24,19 @@ import tachiyomi.presentation.core.util.plus
 @Composable
 fun BrowseMangaSourceList(
     mangaList: LazyPagingItems<StateFlow<Manga>>,
+    entries: Int,
+    topBarHeight: Int,
     contentPadding: PaddingValues,
     onMangaClick: (Manga) -> Unit,
     onMangaLongClick: (Manga) -> Unit,
 ) {
+    var containerHeight by remember { mutableIntStateOf(0) }
     LazyColumn(
         contentPadding = contentPadding + PaddingValues(vertical = 8.dp),
+        modifier = Modifier
+            .onGloballyPositioned { layoutCoordinates ->
+                containerHeight = layoutCoordinates.size.height - topBarHeight
+            }
     ) {
         item {
             if (mangaList.loadState.prepend is LoadState.Loading) {
@@ -38,6 +50,8 @@ fun BrowseMangaSourceList(
                 manga = manga,
                 onClick = { onMangaClick(manga) },
                 onLongClick = { onMangaLongClick(manga) },
+                entries = entries,
+                containerHeight = containerHeight,
             )
         }
 
@@ -54,6 +68,8 @@ private fun BrowseMangaSourceListItem(
     manga: Manga,
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = onClick,
+    entries: Int,
+    containerHeight: Int,
 ) {
     EntryListItem(
         title = manga.title,
@@ -70,5 +86,7 @@ private fun BrowseMangaSourceListItem(
         },
         onLongClick = onLongClick,
         onClick = onClick,
+        entries = entries,
+        containerHeight = containerHeight,
     )
 }

--- a/app/src/main/java/eu/kanade/presentation/browse/manga/components/BrowseMangaSourceList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/manga/components/BrowseMangaSourceList.kt
@@ -36,7 +36,7 @@ fun BrowseMangaSourceList(
         modifier = Modifier
             .onGloballyPositioned { layoutCoordinates ->
                 containerHeight = layoutCoordinates.size.height - topBarHeight
-            }
+            },
     ) {
         item {
             if (mangaList.loadState.prepend is LoadState.Loading) {

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonEntryItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonEntryItem.kt
@@ -339,22 +339,17 @@ fun EntryListItem(
     onClick: () -> Unit,
     badge: @Composable (RowScope.() -> Unit),
     onClickContinueViewing: (() -> Unit)? = null,
-    entries: Int = -1,
+    entries: Int = 0,
     containerHeight: Int = 0,
 ) {
-    val density = LocalDensity.current
     Row(
         modifier = Modifier
             .selectedBackground(isSelected)
             .height(
                 when (entries) {
-                    -1 -> {
-                        76.dp
-                    }
-                    0 -> {
-                        with(density) { (containerHeight / 7).toDp() } - (3 / 7).dp
-                    }
+                    0 -> 76.dp
                     else -> {
+                        val density = LocalDensity.current
                         with(density) { (containerHeight / entries).toDp() } - (3 / entries).dp
                     }
                 },
@@ -377,7 +372,6 @@ fun EntryListItem(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .weight(1f),
-            // maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             style = MaterialTheme.typography.bodyMedium,
         )

--- a/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibrarySettingsDialog.kt
@@ -276,7 +276,7 @@ private fun ColumnScope.DisplayPage(
             max = 10,
             value = columns,
             valueText = if (columns > 0) {
-                stringResource(MR.strings.pref_library_columns_per_row, columns)
+                stringResource(MR.strings.pref_library_columns_per_row, columns,)
             } else {
                 stringResource(MR.strings.label_default)
             },

--- a/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibrarySettingsDialog.kt
@@ -276,7 +276,7 @@ private fun ColumnScope.DisplayPage(
             max = 10,
             value = columns,
             valueText = if (columns > 0) {
-                stringResource(MR.strings.pref_library_columns_per_row, columns,)
+                stringResource(MR.strings.pref_library_columns_per_row, columns)
             } else {
                 stringResource(MR.strings.label_default)
             },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/source/browse/BrowseAnimeSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/source/browse/BrowseAnimeSourceScreen.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalUriHandler
@@ -124,9 +127,15 @@ data class BrowseAnimeSourceScreen(
             assistUrl = (screenModel.source as? AnimeHttpSource)?.baseUrl
         }
 
+        var topBarHeight by remember { mutableIntStateOf(0) }
         Scaffold(
             topBar = {
-                Column(modifier = Modifier.background(MaterialTheme.colorScheme.surface)) {
+                Column(modifier = Modifier
+                    .background(MaterialTheme.colorScheme.surface)
+                    .onGloballyPositioned { layoutCoordinates ->
+                        topBarHeight = layoutCoordinates.size.height
+                    },
+                ) {
                     BrowseAnimeSourceToolbar(
                         searchQuery = state.toolbarQuery,
                         onSearchQueryChange = screenModel::setToolbarQuery,
@@ -214,6 +223,8 @@ data class BrowseAnimeSourceScreen(
                 source = screenModel.source,
                 animeList = pagingFlow.collectAsLazyPagingItems(),
                 columns = screenModel.getColumnsPreference(LocalConfiguration.current.orientation),
+                entries = screenModel.getColumnsPreferenceForCurrentOrientation(LocalConfiguration.current.orientation),
+                topBarHeight = topBarHeight,
                 displayMode = screenModel.displayMode,
                 snackbarHostState = snackbarHostState,
                 contentPadding = paddingValues,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/source/browse/BrowseAnimeSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/source/browse/BrowseAnimeSourceScreen.kt
@@ -130,11 +130,12 @@ data class BrowseAnimeSourceScreen(
         var topBarHeight by remember { mutableIntStateOf(0) }
         Scaffold(
             topBar = {
-                Column(modifier = Modifier
-                    .background(MaterialTheme.colorScheme.surface)
-                    .onGloballyPositioned { layoutCoordinates ->
-                        topBarHeight = layoutCoordinates.size.height
-                    },
+                Column(
+                    modifier = Modifier
+                        .background(MaterialTheme.colorScheme.surface)
+                        .onGloballyPositioned { layoutCoordinates ->
+                            topBarHeight = layoutCoordinates.size.height
+                        },
                 ) {
                     BrowseAnimeSourceToolbar(
                         searchQuery = state.toolbarQuery,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/source/browse/BrowseAnimeSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/source/browse/BrowseAnimeSourceScreenModel.kt
@@ -134,6 +134,16 @@ class BrowseAnimeSourceScreenModel(
         return if (columns == 0) GridCells.Adaptive(128.dp) else GridCells.Fixed(columns)
     }
 
+    // returns the number from the size slider
+    fun getColumnsPreferenceForCurrentOrientation(orientation: Int) : Int {
+        val isLandscape = orientation == Configuration.ORIENTATION_LANDSCAPE
+        return if (isLandscape) {
+            libraryPreferences.animeLandscapeColumns()
+        } else {
+            libraryPreferences.animePortraitColumns()
+        }.get()
+    }
+
     fun resetFilters() {
         if (source !is AnimeCatalogueSource) return
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/source/browse/BrowseAnimeSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/source/browse/BrowseAnimeSourceScreenModel.kt
@@ -135,7 +135,7 @@ class BrowseAnimeSourceScreenModel(
     }
 
     // returns the number from the size slider
-    fun getColumnsPreferenceForCurrentOrientation(orientation: Int) : Int {
+    fun getColumnsPreferenceForCurrentOrientation(orientation: Int): Int {
         val isLandscape = orientation == Configuration.ORIENTATION_LANDSCAPE
         return if (isLandscape) {
             libraryPreferences.animeLandscapeColumns()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/source/browse/BrowseMangaSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/source/browse/BrowseMangaSourceScreen.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalUriHandler
@@ -124,9 +127,15 @@ data class BrowseMangaSourceScreen(
             assistUrl = (screenModel.source as? HttpSource)?.baseUrl
         }
 
+        var topBarHeight by remember { mutableIntStateOf(0) }
         Scaffold(
             topBar = {
-                Column(modifier = Modifier.background(MaterialTheme.colorScheme.surface)) {
+                Column(modifier = Modifier
+                    .background(MaterialTheme.colorScheme.surface)
+                    .onGloballyPositioned { layoutCoordinates ->
+                        topBarHeight = layoutCoordinates.size.height
+                    },
+                ) {
                     BrowseMangaSourceToolbar(
                         searchQuery = state.toolbarQuery,
                         onSearchQueryChange = screenModel::setToolbarQuery,
@@ -214,6 +223,8 @@ data class BrowseMangaSourceScreen(
                 source = screenModel.source,
                 mangaList = pagingFlow.collectAsLazyPagingItems(),
                 columns = screenModel.getColumnsPreference(LocalConfiguration.current.orientation),
+                entries = screenModel.getColumnsPreferenceForCurrentOrientation(LocalConfiguration.current.orientation),
+                topBarHeight = topBarHeight,
                 displayMode = screenModel.displayMode,
                 snackbarHostState = snackbarHostState,
                 contentPadding = paddingValues,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/source/browse/BrowseMangaSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/source/browse/BrowseMangaSourceScreen.kt
@@ -130,11 +130,12 @@ data class BrowseMangaSourceScreen(
         var topBarHeight by remember { mutableIntStateOf(0) }
         Scaffold(
             topBar = {
-                Column(modifier = Modifier
-                    .background(MaterialTheme.colorScheme.surface)
-                    .onGloballyPositioned { layoutCoordinates ->
-                        topBarHeight = layoutCoordinates.size.height
-                    },
+                Column(
+                    modifier = Modifier
+                        .background(MaterialTheme.colorScheme.surface)
+                        .onGloballyPositioned { layoutCoordinates ->
+                            topBarHeight = layoutCoordinates.size.height
+                        },
                 ) {
                     BrowseMangaSourceToolbar(
                         searchQuery = state.toolbarQuery,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/source/browse/BrowseMangaSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/source/browse/BrowseMangaSourceScreenModel.kt
@@ -134,6 +134,16 @@ class BrowseMangaSourceScreenModel(
         return if (columns == 0) GridCells.Adaptive(128.dp) else GridCells.Fixed(columns)
     }
 
+    // returns the number from the size slider
+    fun getColumnsPreferenceForCurrentOrientation(orientation: Int) : Int {
+        val isLandscape = orientation == Configuration.ORIENTATION_LANDSCAPE
+        return if (isLandscape) {
+            libraryPreferences.mangaLandscapeColumns()
+        } else {
+            libraryPreferences.mangaPortraitColumns()
+        }.get()
+    }
+
     fun resetFilters() {
         if (source !is CatalogueSource) return
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/source/browse/BrowseMangaSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/source/browse/BrowseMangaSourceScreenModel.kt
@@ -135,7 +135,7 @@ class BrowseMangaSourceScreenModel(
     }
 
     // returns the number from the size slider
-    fun getColumnsPreferenceForCurrentOrientation(orientation: Int) : Int {
+    fun getColumnsPreferenceForCurrentOrientation(orientation: Int): Int {
         val isLandscape = orientation == Configuration.ORIENTATION_LANDSCAPE
         return if (isLandscape) {
             libraryPreferences.mangaLandscapeColumns()


### PR DESCRIPTION
I came to the conclusion that setting number 7 as the default wouldn't be ideal. Some people might've enjoyed the original list because it would scale with their phone UI if they changed it. I now made the default to be a set value like both the migration list and browse list. It doesn't take away any options because users can just put 7 themselves on the slider. And it's faithful to the previous list.

it's a 3 line change, guys. I hope someone can find some time to merge this in.

(fixup to 2b1dbc18789bfb7018e8ae41c6b7665ed4c3e433)

Edit: well... it's a bit more than 3 lines now, but it now fixes a glitch where the browse list didn't scale like the library list does.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
