### PR TITLE
feat(migrations): Remove `cacert.pem` on version bump

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
     defaultConfig {
         applicationId = "xyz.jmir.tachiyomi.mi"
 
-        versionCode = 127
+        versionCode = 128
         versionName = "0.16.4.3"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getCommitCount()}\"")

--- a/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
@@ -46,4 +46,5 @@ val migrations: List<Migration>
         TrustExtensionRepositoryMigration(),
         VideoPlayerPreferenceMigration(),
         VideoOrientationMigration(),
+        PEMFileMigration(),
     )

--- a/app/src/main/java/mihon/core/migration/migrations/PEMFileMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/PEMFileMigration.kt
@@ -1,0 +1,31 @@
+package mihon.core.migration.migrations
+
+import android.app.Application
+import android.os.Build
+import android.os.Environment
+import mihon.core.migration.Migration
+import mihon.core.migration.MigrationContext
+import tachiyomi.domain.storage.service.StorageManager
+import java.io.File
+
+class PEMFileMigration : Migration {
+    override val version: Float = Migration.ALWAYS
+
+    override suspend fun invoke(migrationContext: MigrationContext): Boolean {
+        val storageManager = migrationContext.get<StorageManager>() ?: return false
+        val context = migrationContext.get<Application>() ?: return false
+
+        val configDir = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && Environment.isExternalStorageManager()) {
+            storageManager.getMPVConfigDirectory()!!.filePath!!
+        } else {
+            context.applicationContext.filesDir.path
+        }
+
+        val pemFile = File(configDir, "cacert.pem")
+        if (pemFile.exists()) {
+            pemFile.delete()
+        }
+
+        return true
+    }
+}


### PR DESCRIPTION
I'm not sure how or why, but something goes wrong when updating the mpv-lib, causing users to get a malformed .pem file and being unable to play anything. We just need to remember to bump the app version whenever we update mpv-lib, or we could copy over the .pem file every time a video is loaded.
