### PR TITLE
fix(external-player): Prevent crash on app death

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -107,6 +107,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import logcat.LogPriority
 import mihon.core.migration.Migrator
 import tachiyomi.core.common.i18n.stringResource
@@ -304,6 +305,15 @@ class MainActivity : BaseActivity() {
             ActivityResultContracts.StartActivityForResult(),
         ) { result: ActivityResult ->
             if (result.resultCode == Activity.RESULT_OK) {
+                val animeId = savedInstanceState?.getLong(SAVED_STATE_ANIME_KEY)
+                val episodeId = savedInstanceState?.getLong(SAVED_STATE_EPISODE_KEY)
+
+                if (animeId != null && episodeId != null) {
+                    runBlocking {
+                        ExternalIntents.externalIntents.initAnime(animeId, episodeId)
+                    }
+                }
+
                 ExternalIntents.externalIntents.onActivityResult(result.data)
             }
         }
@@ -536,12 +546,26 @@ class MainActivity : BaseActivity() {
         return true
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+
+        ExternalIntents.externalIntents.animeId?.let {
+            outState.putLong(SAVED_STATE_ANIME_KEY, it)
+        }
+        ExternalIntents.externalIntents.episodeId?.let {
+            outState.putLong(SAVED_STATE_EPISODE_KEY, it)
+        }
+    }
+
     companion object {
         const val INTENT_SEARCH = "eu.kanade.tachiyomi.SEARCH"
         const val INTENT_ANIMESEARCH = "eu.kanade.tachiyomi.ANIMESEARCH"
         const val INTENT_SEARCH_QUERY = "query"
         const val INTENT_SEARCH_FILTER = "filter"
         const val INTENT_SEARCH_TYPE = "type"
+
+        const val SAVED_STATE_ANIME_KEY = "saved_state_anime_key"
+        const val SAVED_STATE_EPISODE_KEY = "saved_state_episode_key"
 
         private var externalPlayerResult: ActivityResultLauncher<Intent>? = null
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
@@ -63,6 +63,9 @@ class ExternalIntents {
     lateinit var source: AnimeSource
     lateinit var episode: Episode
 
+    var animeId: Long? = null
+    var episodeId: Long? = null
+
     /**
      * Returns the [Intent] to be sent to an external player.
      *
@@ -76,9 +79,7 @@ class ExternalIntents {
         episodeId: Long,
         chosenVideo: Video?,
     ): Intent? {
-        anime = getAnime.await(animeId) ?: return null
-        source = sourceManager.get(anime.source) ?: return null
-        episode = getEpisodesByAnimeId.await(anime.id).find { it.id == episodeId } ?: return null
+        if (!initAnime(animeId, episodeId)) return null
 
         val video = chosenVideo
             ?: EpisodeLoader.getLinks(episode, anime, source).firstOrNull()
@@ -97,6 +98,17 @@ class ExternalIntents {
         } else {
             getIntentForPackage(pkgName, context, videoUrl, video)
         }
+    }
+
+    suspend fun initAnime(animeId: Long, episodeId: Long): Boolean {
+        anime = getAnime.await(animeId) ?: return false
+        source = sourceManager.get(anime.source) ?: return false
+        episode = getEpisodesByAnimeId.await(anime.id).find { it.id == episodeId } ?: return false
+
+        this.animeId = animeId
+        this.episodeId = episodeId
+
+        return true
     }
 
     /**
@@ -339,6 +351,8 @@ class ExternalIntents {
     @Suppress("DEPRECATION")
     fun onActivityResult(intent: Intent?) {
         val data = intent ?: return
+        if (animeId == null || episodeId == null) return
+
         val anime = anime
         val currentExtEpisode = episode
         val currentPosition: Long


### PR DESCRIPTION
Save state to bundle to restore upon exiting the external player. Even if it somehow fails to save to the bundle, it will just do nothing instead of crashing the app