### PR TITLE
fix(player): Don't run unnecessary stuff when exiting the player

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -269,17 +269,23 @@ class PlayerActivity : BaseActivity() {
     }
 
     override fun onDestroy() {
+        player.isExiting = true
+
         audioFocusRequest?.let {
             AudioManagerCompat.abandonAudioFocusRequest(audioManager, it)
         }
         audioFocusRequest = null
-        mediaSession?.release()
+
+        mediaSession?.let {
+            it.isActive = false
+            it.release()
+        }
+
         if (noisyReceiver.initialized) {
             unregisterReceiver(noisyReceiver)
             noisyReceiver.initialized = false
         }
 
-        player.isExiting = true
         MPVLib.removeLogObserver(playerObserver)
         MPVLib.removeObserver(playerObserver)
         player.destroy()
@@ -288,16 +294,22 @@ class PlayerActivity : BaseActivity() {
     }
 
     override fun onPause() {
-        if (!isInPictureInPictureMode) {
-            viewModel.pause()
-        }
         viewModel.saveCurrentEpisodeWatchingProgress()
+
+        if (isInPictureInPictureMode) {
+            super.onPause()
+            return
+        }
+
+        player.isExiting = true
+        if (isFinishing) {
+            MPVLib.command(arrayOf("stop"))
+        }
+
         super.onPause()
     }
 
     override fun onStop() {
-        viewModel.pause()
-        viewModel.saveCurrentEpisodeWatchingProgress()
         window.attributes.screenBrightness.let {
             if (playerPreferences.rememberPlayerBrightness().get() && it != -1f) {
                 playerPreferences.playerBrightnessValue().set(it)


### PR DESCRIPTION
Closes #1882

Sometimes it will still hang when exiting the player, causing the app to be unresponsive for a short while (which I have no why it's happening) but now it won't at least cause an ANR.