### PR TITLE
UI: add titles to player sheets + consistency with More sheet

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerSheets.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerSheets.kt
@@ -129,7 +129,7 @@ fun PlayerSheets(
                 onSelect = onSelectAudio,
                 onAddAudioTrack = { audioPicker.launch(arrayOf("*/*")) },
                 onOpenDelayPanel = { onOpenPanel(Panels.AudioDelay) },
-                onDismissRequest,
+                onDismissRequest = onDismissRequest,
             )
         }
 
@@ -150,7 +150,7 @@ fun PlayerSheets(
         Sheets.Chapters -> {
             if (chapter == null) return
             ChaptersSheet(
-                chapters,
+                chapters = chapters,
                 currentChapter = chapter,
                 onClick = { onSeekToChapter(chapters.indexOf(it)) },
                 onDismissRequest = onDismissRequest,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/AudioTracksSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/AudioTracksSheet.kt
@@ -25,10 +25,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreTime
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -51,17 +51,27 @@ fun AudioTracksSheet(
     modifier: Modifier = Modifier,
 ) {
     GenericTracksSheet(
-        tracks,
+        tracks = tracks,
         onDismissRequest = onDismissRequest,
         header = {
-            AddTrackRow(
-                stringResource(MR.strings.player_sheets_add_ext_audio),
-                onAddAudioTrack,
+            TrackSheetTitle(
+                title = stringResource(MR.strings.pref_player_audio),
                 actions = {
-                    IconButton(onClick = onOpenDelayPanel) {
-                        Icon(Icons.Default.MoreTime, null)
+                    TextButton(onClick = onOpenDelayPanel) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
+                        ) {
+                            Icon(imageVector = Icons.Default.MoreTime, contentDescription = null)
+                            Text(text = stringResource(MR.strings.player_sheets_track_delay))
+                        }
                     }
                 },
+            )
+
+            AddTrackRow(
+                title = stringResource(MR.strings.player_sheets_add_ext_audio),
+                onClick = onAddAudioTrack,
             )
         },
         track = {
@@ -91,8 +101,8 @@ fun AudioTrackRow(
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
     ) {
         RadioButton(
-            isSelected,
-            onClick,
+            selected = isSelected,
+            onClick = onClick,
         )
         Text(
             title,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/ChaptersSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/ChaptersSheet.kt
@@ -46,10 +46,16 @@ fun ChaptersSheet(
     modifier: Modifier = Modifier,
 ) {
     GenericTracksSheet(
-        chapters,
+        tracks = chapters,
+        header = {
+            TrackSheetTitle(
+                title = stringResource(MR.strings.player_sheets_chapters_title),
+                modifier = modifier.padding(top = MaterialTheme.padding.small),
+            )
+        },
         track = {
             ChapterTrack(
-                it,
+                chapter = it,
                 index = chapters.indexOf(it),
                 selected = currentChapter == it,
                 onClick = { onClick(it) },
@@ -57,8 +63,7 @@ fun ChaptersSheet(
         },
         onDismissRequest = onDismissRequest,
         dismissEvent = dismissSheet,
-        modifier = modifier
-            .padding(vertical = MaterialTheme.padding.medium),
+        modifier = modifier,
     )
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/GenericTracksSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/GenericTracksSheet.kt
@@ -95,11 +95,11 @@ fun AddTrackRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
-                Icons.Default.Add,
-                null,
+                imageVector = Icons.Default.Add,
+                contentDescription = null,
                 modifier = Modifier.size(32.dp),
             )
-            Text(title)
+            Text(text = title)
         }
         actions()
     }
@@ -125,5 +125,35 @@ fun getTrackTitle(track: VideoTrack): String {
         }
 
         else -> stringResource(MR.strings.player_sheets_track_title_wo_lang, track.id, track.name)
+    }
+}
+
+@Composable
+fun TrackSheetTitle(
+    title: String,
+    modifier: Modifier = Modifier,
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    Row(
+        modifier = modifier.fillMaxWidth()
+            .padding(
+                start = MaterialTheme.padding.medium,
+                end = MaterialTheme.padding.medium,
+                top = MaterialTheme.padding.small,
+                bottom = MaterialTheme.padding.extraSmall,
+            ),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineMedium,
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
+        ) {
+            actions()
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/MoreSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/MoreSheet.kt
@@ -96,8 +96,8 @@ fun MoreSheet(
     val statisticsPage by advancedPreferences.playerStatisticsPage().collectAsState()
 
     PlayerSheet(
-        onDismissRequest,
-        modifier,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/QualitySheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/QualitySheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -90,55 +91,69 @@ fun QualitySheet(
         dismissEvent = dismissSheet,
         modifier = modifier,
     ) {
-        AnimatedVisibility(
-            visible = isLoadingHosters,
-            enter = fadeIn() + slideInVertically(
-                initialOffsetY = { it / 2 },
-            ),
-            exit = fadeOut() + slideOutVertically(
-                targetOffsetY = { it / 2 },
-            ),
-        ) {
-            Box(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(vertical = MaterialTheme.padding.medium),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
-            }
-        }
+        Column {
+            Text(
+                text = stringResource(MR.strings.player_sheets_quality_title),
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.padding(
+                    top = MaterialTheme.padding.medium,
+                    start = MaterialTheme.padding.medium,
+                    bottom = MaterialTheme.padding.extraSmall,
+                ),
+            )
 
-        AnimatedVisibility(
-            visible = !isLoadingHosters,
-            enter = fadeIn() + slideInVertically(
-                initialOffsetY = { it / 2 },
-            ),
-            exit = fadeOut() + slideOutVertically(
-                targetOffsetY = { it / 2 },
-            ),
-        ) {
-            if (hosterState.size == 1 &&
-                hosterState.first().name == Hoster.NO_HOSTER_LIST &&
-                hosterState.first() is HosterState.Ready
+            AnimatedVisibility(
+                visible = isLoadingHosters,
+                enter = fadeIn() + slideInVertically(initialOffsetY = { it / 2 }),
+                exit = fadeOut() + slideOutVertically(targetOffsetY = { it / 2 }),
             ) {
-                QualitySheetVideoContent(
-                    videoList = (hosterState.first() as HosterState.Ready).videoList,
-                    videoState = (hosterState.first() as HosterState.Ready).videoState,
-                    selectedVideoIndex = selectedVideoIndex.second,
-                    onClickVideo = onClickVideo,
-                    modifier = modifier.padding(MaterialTheme.padding.medium),
-                )
-            } else {
-                QualitySheetHosterContent(
-                    hosterState = hosterState,
-                    expandedState = expandedState,
-                    selectedVideoIndex = selectedVideoIndex,
-                    onClickHoster = onClickHoster,
-                    onClickVideo = onClickVideo,
-                    displayHosters = displayHosters,
-                    modifier = modifier.padding(MaterialTheme.padding.medium),
-                )
+                Box(
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .padding(vertical = MaterialTheme.padding.medium),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            val qualitySheetPadding = PaddingValues(
+                bottom = MaterialTheme.padding.medium,
+                start = MaterialTheme.padding.medium,
+                end = MaterialTheme.padding.medium,
+            )
+
+            AnimatedVisibility(
+                visible = !isLoadingHosters,
+                enter = fadeIn() + slideInVertically(
+                    initialOffsetY = { it / 2 },
+                ),
+                exit = fadeOut() + slideOutVertically(
+                    targetOffsetY = { it / 2 },
+                ),
+            ) {
+                if (hosterState.size == 1 &&
+                    hosterState.first().name == Hoster.NO_HOSTER_LIST &&
+                    hosterState.first() is HosterState.Ready
+                ) {
+                    QualitySheetVideoContent(
+                        videoList = (hosterState.first() as HosterState.Ready).videoList,
+                        videoState = (hosterState.first() as HosterState.Ready).videoState,
+                        selectedVideoIndex = selectedVideoIndex.second,
+                        onClickVideo = onClickVideo,
+                        modifier = modifier.padding(paddingValues = qualitySheetPadding),
+                    )
+                } else {
+                    QualitySheetHosterContent(
+                        hosterState = hosterState,
+                        expandedState = expandedState,
+                        selectedVideoIndex = selectedVideoIndex,
+                        onClickHoster = onClickHoster,
+                        onClickVideo = onClickVideo,
+                        displayHosters = displayHosters,
+                        modifier = modifier.padding(paddingValues = qualitySheetPadding),
+                    )
+                }
             }
         }
     }
@@ -152,10 +167,7 @@ fun QualitySheetVideoContent(
     onClickVideo: (Int, Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
-        modifier
-            .fillMaxWidth(),
-    ) {
+    LazyColumn(modifier = modifier.fillMaxWidth()) {
         itemsIndexed(videoList) { videoIdx, video ->
             VideoTrack(
                 video = video,
@@ -190,9 +202,7 @@ fun QualitySheetHosterContent(
         state is HosterState.Ready && state.videoList.isEmpty()
     }
 
-    LazyColumn(
-        modifier.fillMaxWidth(),
-    ) {
+    LazyColumn(modifier = modifier.fillMaxWidth()) {
         hosterContent(
             hosters = validHosters,
             expandedState = expandedState,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/QualitySheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/QualitySheet.kt
@@ -93,7 +93,7 @@ fun QualitySheet(
     ) {
         Column {
             Text(
-                text = stringResource(MR.strings.player_sheets_quality_title),
+                text = stringResource(MR.strings.player_sheets_qualities_title),
                 style = MaterialTheme.typography.headlineMedium,
                 modifier = Modifier.padding(
                     top = MaterialTheme.padding.medium,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/SubtitleTracksSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/SubtitleTracksSheet.kt
@@ -30,9 +30,9 @@ import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -56,20 +56,35 @@ fun SubtitlesSheet(
     modifier: Modifier = Modifier,
 ) {
     GenericTracksSheet(
-        tracks,
+        tracks = tracks,
         onDismissRequest = onDismissRequest,
         header = {
-            AddTrackRow(
-                stringResource(MR.strings.player_sheets_add_ext_sub),
-                onAddSubtitle,
+            TrackSheetTitle(
+                title = stringResource(MR.strings.pref_player_subtitle),
                 actions = {
-                    IconButton(onClick = onOpenSubtitleSettings) {
-                        Icon(Icons.Default.Palette, null)
+                    TextButton(onClick = onOpenSubtitleSettings) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
+                        ) {
+                            Icon(imageVector = Icons.Default.Palette, contentDescription = null)
+                            Text(text = stringResource(MR.strings.player_sheets_track_palette))
+                        }
                     }
-                    IconButton(onClick = onOpenSubtitleDelay) {
-                        Icon(Icons.Default.MoreTime, null)
+                    TextButton(onClick = onOpenSubtitleDelay) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
+                        ) {
+                            Icon(imageVector = Icons.Default.MoreTime, contentDescription = null)
+                            Text(text = stringResource(MR.strings.player_sheets_track_delay))
+                        }
                     }
                 },
+            )
+            AddTrackRow(
+                title = stringResource(MR.strings.player_sheets_add_ext_sub),
+                onClick = onAddSubtitle,
             )
         },
         track = { track ->
@@ -110,18 +125,18 @@ fun SubtitleTrackRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Checkbox(
-            selected > -1,
+            checked = selected > -1,
             onCheckedChange = { _ -> onClick() },
         )
         Text(
-            title,
+            text = title,
             fontStyle = if (selected > -1) FontStyle.Italic else FontStyle.Normal,
             fontWeight = if (selected > -1) FontWeight.ExtraBold else FontWeight.Normal,
         )
         Spacer(modifier = Modifier.weight(1f))
         if (selected != -1) {
             Text(
-                "#${selected + 1}",
+                text = "#${selected + 1}",
                 fontStyle = if (selected > -1) FontStyle.Italic else FontStyle.Normal,
                 fontWeight = if (selected > -1) FontWeight.ExtraBold else FontWeight.Normal,
             )

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -399,6 +399,8 @@
     <string name="player_sheets_track_title_w_lang" translatable="false">#%d: %s (%s)</string>
     <string name="player_sheets_track_title_wo_lang" translatable="false">#%d: %s</string>
     <string name="player_sheets_track_lang_wo_title" translatable="false">#%d: %s</string>
+    <string name="player_sheets_track_delay">Delay</string>
+    <string name="player_sheets_track_palette">Palette</string>
 
     <!-- Sheets - Audio delay -->
     <string name="player_sheets_audio_delay_title">Audio delay</string>
@@ -467,6 +469,7 @@
     <!-- Sheets - Quality list -->
     <string name="player_hoster_tap_to_load">Tap to load videos</string>
     <string name="player_hoster_failed">Failed to load videos</string>
+    <string name="player_sheets_quality_title">Quality</string>
 
     <!-- Sheets - Decoders -->
     <string name="player_sheets_decoder_formatted">%s (%s)</string>
@@ -500,6 +503,9 @@
 
     <!-- Sheets - screenshot -->
     <string name="screenshot_show_subs">Include Subtitles</string>
+
+    <!-- Sheets - Chapters -->
+    <string name="player_sheets_chapters_title">Chapters</string>
 
     <!-- Subsections -->
     <string name="pref_category_general">General</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -469,7 +469,7 @@
     <!-- Sheets - Quality list -->
     <string name="player_hoster_tap_to_load">Tap to load videos</string>
     <string name="player_hoster_failed">Failed to load videos</string>
-    <string name="player_sheets_quality_title">Quality</string>
+    <string name="player_sheets_qualities_title">Qualities</string>
 
     <!-- Sheets - Decoders -->
     <string name="player_sheets_decoder_formatted">%s (%s)</string>


### PR DESCRIPTION
Changes
---
- Added titles to player sheets
    - Chapters
    - Subtitles
    - Audio
    - Qualities 
- Shifted Audio and Subtitle actions upwards, inline with title
- Updated colours and text to match the actions in the More sheet

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
