### PR TITLE
feat(renovate): Only check for aniyomi-specific libs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,9 +5,18 @@
   "semanticCommits": "disabled",
   "packageRules": [
     {
-      "groupName": "GitHub Actions",
-      "matchManagers": ["github-actions"],
-      "pinDigests": true,
+      "matchManagers": ["gradle"],
+      "matchPackagePatterns": ["*"],
+      "excludePackagePatterns": [
+        "^androidx.constraintlayout:constraintlayout-compose",
+        "^androidx.media:media",
+        "^com.github.aniyomiorg:aniyomi-mpv-lib",
+        "^com.github.jmir1:ffmpeg-kit",
+        "^com.arthenica:smart-exception-java",
+        "^io.github.2307vivek:seeker",
+        "^io.github.yubyf:truetypeparser-light",
+      ],
+      "enabled": false,
     },
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,21 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "labels": ["Dependencies"],
+  "includePaths": ["gradle/aniyomi.versions.toml"],
   "semanticCommits": "disabled",
-  "packageRules": [
-    {
-      "matchManagers": ["gradle"],
-      "matchPackagePatterns": ["*"],
-      "excludePackagePatterns": [
-        "^androidx.constraintlayout:constraintlayout-compose",
-        "^androidx.media:media",
-        "^com.github.aniyomiorg:aniyomi-mpv-lib",
-        "^com.github.jmir1:ffmpeg-kit",
-        "^com.arthenica:smart-exception-java",
-        "^io.github.2307vivek:seeker",
-        "^io.github.yubyf:truetypeparser-light",
-      ],
-      "enabled": false,
-    },
-  ],
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -221,13 +221,13 @@ dependencies {
     implementation(androidx.appcompat)
     implementation(androidx.biometricktx)
     implementation(androidx.constraintlayout)
-    implementation(androidx.compose.constraintlayout)
+    implementation(aniyomilibs.compose.constraintlayout)
     implementation(androidx.corektx)
     implementation(androidx.splashscreen)
     implementation(androidx.recyclerview)
     implementation(androidx.viewpager)
     implementation(androidx.profileinstaller)
-    implementation(androidx.mediasession)
+    implementation(aniyomilibs.mediasession)
 
     implementation(androidx.bundles.lifecycle)
 
@@ -300,14 +300,14 @@ dependencies {
     testImplementation(kotlinx.coroutines.test)
 
     // mpv-android
-    implementation(libs.aniyomi.mpv)
+    implementation(aniyomilibs.aniyomi.mpv)
     // FFmpeg-kit
-    implementation(libs.ffmpeg.kit)
-    implementation(libs.arthenica.smartexceptions)
+    implementation(aniyomilibs.ffmpeg.kit)
+    implementation(aniyomilibs.arthenica.smartexceptions)
     // seeker seek bar
-    implementation(libs.seeker)
+    implementation(aniyomilibs.seeker)
     // true type parser
-    implementation(libs.truetypeparser)
+    implementation(aniyomilibs.truetypeparser)
 }
 
 androidComponents {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -12,6 +12,9 @@ dependencyResolutionManagement {
         create("kotlinx") {
             from(files("../gradle/kotlinx.versions.toml"))
         }
+        create("aniyomilibs") {
+            from(files("../gradle/aniyomi.versions.toml"))
+        }
     }
 }
 

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     implementation(libs.bundles.js.engine)
 
     // FFmpeg-kit
-    implementation(libs.ffmpeg.kit)
+    implementation(aniyomilibs.ffmpeg.kit)
 
     // Tests
     testImplementation(libs.bundles.test)

--- a/gradle/androidx.versions.toml
+++ b/gradle/androidx.versions.toml
@@ -11,13 +11,11 @@ annotation = "androidx.annotation:annotation:1.9.1"
 appcompat = "androidx.appcompat:appcompat:1.7.0"
 biometricktx = "androidx.biometric:biometric-ktx:1.2.0-alpha05"
 constraintlayout = "androidx.constraintlayout:constraintlayout:2.2.1"
-compose-constraintlayout = "androidx.constraintlayout:constraintlayout-compose:1.1.0"
 corektx = "androidx.core:core-ktx:1.15.0"
 splashscreen = "androidx.core:core-splashscreen:1.0.1"
 recyclerview = "androidx.recyclerview:recyclerview:1.4.0"
 viewpager = "androidx.viewpager:viewpager:1.1.0"
 profileinstaller = "androidx.profileinstaller:profileinstaller:1.4.1"
-mediasession = "androidx.media:media:1.7.0"
 
 lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "lifecycle_version" }
 lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle_version" }

--- a/gradle/aniyomi.versions.toml
+++ b/gradle/aniyomi.versions.toml
@@ -1,0 +1,17 @@
+[versions]
+aniyomi-mpv-lib = "1.17.n"
+arthenica-smartexceptions = "0.2.1"
+constraint-layout = "1.1.0"
+ffmpeg-kit = "1.17"
+media = "1.7.0"
+seeker = "1.2.2"
+truetypeparser = "2.1.4"
+
+[libraries]
+aniyomi-mpv = { module = "com.github.aniyomiorg:aniyomi-mpv-lib", version.ref = "aniyomi-mpv-lib" }
+arthenica-smartexceptions = { module = "com.arthenica:smart-exception-java", version.ref = "arthenica-smartexceptions" }
+compose-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraint-layout" }
+ffmpeg-kit = { module = "com.github.jmir1:ffmpeg-kit", version.ref = "ffmpeg-kit" }
+mediasession = { module = "androidx.media:media", version.ref = "media" }
+seeker = { module = "io.github.2307vivek:seeker", version.ref = "seeker" }
+truetypeparser = { module = "io.github.yubyf:truetypeparser-light", version.ref = "truetypeparser" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,14 +94,6 @@ voyager-screenmodel = { module = "cafe.adriel.voyager:voyager-screenmodel", vers
 voyager-tab-navigator = { module = "cafe.adriel.voyager:voyager-tab-navigator", version.ref = "voyager" }
 voyager-transitions = { module = "cafe.adriel.voyager:voyager-transitions", version.ref = "voyager" }
 
-aniyomi-mpv = "com.github.aniyomiorg:aniyomi-mpv-lib:1.17.n"
-ffmpeg-kit = "com.github.jmir1:ffmpeg-kit:1.17"
-arthenica-smartexceptions = "com.arthenica:smart-exception-java:0.2.1"
-
-seeker = "io.github.2307vivek:seeker:1.2.2"
-
-truetypeparser = "io.github.yubyf:truetypeparser-light:2.1.4"
-
 spotless-gradle = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }
 ktlint-core = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint-core" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,9 @@ dependencyResolutionManagement {
         create("compose") {
             from(files("gradle/compose.versions.toml"))
         }
+        create("aniyomilibs") {
+            from(files("gradle/aniyomi.versions.toml"))
+        }
     }
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {

--- a/source-local/build.gradle.kts
+++ b/source-local/build.gradle.kts
@@ -49,6 +49,6 @@ android {
 
     dependencies {
         // FFmpeg-kit
-        implementation(libs.ffmpeg.kit)
+        implementation(aniyomilibs.ffmpeg.kit)
     }
 }


### PR DESCRIPTION
Since dependencies gets bumped from mihon, there's no point in telling renovate to check for updates for those packages.