### PR TITLE
fix(download) ffmpeg error blocking additonal download

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
@@ -248,7 +248,8 @@ class AnimeDownloader(
             downloadEpisode(download)
 
             // Remove successful download from queue
-            if (download.status == AnimeDownload.State.DOWNLOADED) {
+            if (download.status == AnimeDownload.State.DOWNLOADED ||
+                download.status == AnimeDownload.State.ERROR) {
                 removeFromQueue(download)
             }
         } catch (e: Throwable) {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/NotificationExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/NotificationExtensions.kt
@@ -36,7 +36,10 @@ fun Context.notify(id: Int, notification: Notification) {
         return
     }
 
-    NotificationManagerCompat.from(this).notify(id, notification)
+    NotificationManagerCompat.from(this).run {
+        cancel(id)
+        notify(id, notification)
+    }
 }
 
 fun Context.notify(notificationWithIdAndTags: List<NotificationWithIdAndTag>) {


### PR DESCRIPTION
this remove a download from queue upon error state, which is blocking the queue when user tries to pick a different video quality or add diff epsiode into queue. also, fix notification not replacing error message of the same id.
