### PR TITLE
feat(settings): Invalidate preferred languages

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         applicationId = "xyz.jmir.tachiyomi.mi"
 
-        versionCode = 129
+        versionCode = 130
         versionName = "0.16.4.3"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getCommitCount()}\"")

--- a/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
@@ -206,6 +206,8 @@ sealed class Preference {
         data class EditTextInfoPreference(
             val preference: PreferenceData<String>,
             val dialogSubtitle: String?,
+            val validate: (String) -> Boolean = { true },
+            val errorMessage: @Composable ((String) -> String)? = null,
             override val title: String,
             override val subtitle: String? = "%s",
             override val icon: ImageVector? = null,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
@@ -211,6 +211,8 @@ internal fun PreferenceItem(
                     },
                     singleLine = true,
                     canBeBlank = true,
+                    validate = item.validate,
+                    errorMessage = item.errorMessage,
                 )
             }
             is Preference.PreferenceItem.TrackerPreference -> {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsAudioScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsAudioScreen.kt
@@ -14,6 +14,8 @@ import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.util.Locale
+import java.util.MissingResourceException
 
 object PlayerSettingsAudioScreen : SearchableSettings {
 
@@ -36,6 +38,42 @@ object PlayerSettingsAudioScreen : SearchableSettings {
                 preference = prefLangs,
                 dialogSubtitle = stringResource(AYMR.strings.pref_player_audio_lang_info),
                 title = stringResource(AYMR.strings.pref_player_audio_lang),
+                validate = { pref ->
+                    val langs = pref.split(",").filter(String::isNotEmpty).map(String::trim)
+                    langs.forEach {
+                        try {
+                            val locale = Locale(it)
+                            if (locale.isO3Language == locale.language &&
+                                locale.language == locale.getDisplayName(Locale.ENGLISH)
+                            ) {
+                                throw MissingResourceException("", "", "")
+                            }
+                        } catch (_: MissingResourceException) {
+                            return@EditTextInfoPreference false
+                        }
+                    }
+
+                    true
+                },
+                errorMessage = { pref ->
+                    val langs = pref.split(",").filter(String::isNotEmpty).map(String::trim)
+                    langs.forEach {
+                        try {
+                            val locale = Locale(it)
+                            if (locale.isO3Language == locale.language &&
+                                locale.language == locale.getDisplayName(Locale.ENGLISH)
+                            ) {
+                                throw MissingResourceException("", "", "")
+                            }
+                        } catch (_: MissingResourceException) {
+                            return@EditTextInfoPreference stringResource(
+                                AYMR.strings.pref_player_subtitle_invalid_lang,
+                                it,
+                            )
+                        }
+                    }
+                    ""
+                },
             ),
             Preference.PreferenceItem.SwitchPreference(
                 preference = pitchCorrection,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsSubtitleScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsSubtitleScreen.kt
@@ -10,6 +10,8 @@ import tachiyomi.i18n.aniyomi.AYMR
 import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.util.Locale
+import java.util.MissingResourceException
 
 object PlayerSettingsSubtitleScreen : SearchableSettings {
 
@@ -30,6 +32,42 @@ object PlayerSettingsSubtitleScreen : SearchableSettings {
                 preference = langPref,
                 dialogSubtitle = stringResource(AYMR.strings.pref_player_subtitle_lang_info),
                 title = stringResource(AYMR.strings.pref_player_subtitle_lang),
+                validate = { pref ->
+                    val langs = pref.split(",").filter(String::isNotEmpty).map(String::trim)
+                    langs.forEach {
+                        try {
+                            val locale = Locale(it)
+                            if (locale.isO3Language == locale.language &&
+                                locale.language == locale.getDisplayName(Locale.ENGLISH)
+                            ) {
+                                throw MissingResourceException("", "", "")
+                            }
+                        } catch (_: MissingResourceException) {
+                            return@EditTextInfoPreference false
+                        }
+                    }
+
+                    true
+                },
+                errorMessage = { pref ->
+                    val langs = pref.split(",").filter(String::isNotEmpty).map(String::trim)
+                    langs.forEach {
+                        try {
+                            val locale = Locale(it)
+                            if (locale.isO3Language == locale.language &&
+                                locale.language == locale.getDisplayName(Locale.ENGLISH)
+                            ) {
+                                throw MissingResourceException("", "", "")
+                            }
+                        } catch (_: MissingResourceException) {
+                            return@EditTextInfoPreference stringResource(
+                                AYMR.strings.pref_player_subtitle_invalid_lang,
+                                it,
+                            )
+                        }
+                    }
+                    ""
+                },
             ),
             Preference.PreferenceItem.EditTextInfoPreference(
                 preference = whitelist,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/EditTextPreferenceWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/EditTextPreferenceWidget.kt
@@ -38,6 +38,8 @@ fun EditTextPreferenceWidget(
     singleLine: Boolean = true,
     canBeBlank: Boolean = false,
     formatSubtitle: Boolean = true,
+    validate: (String) -> Boolean = { true },
+    errorMessage: @Composable ((String) -> String)? = null,
 ) {
     var isDialogShown by remember { mutableStateOf(false) }
 
@@ -69,7 +71,7 @@ fun EditTextPreferenceWidget(
                     value = textFieldValue,
                     onValueChange = { textFieldValue = it },
                     trailingIcon = {
-                        if (textFieldValue.text.isBlank() && !canBeBlank) {
+                        if ((textFieldValue.text.isBlank() && !canBeBlank) || !validate(textFieldValue.text)) {
                             Icon(imageVector = Icons.Filled.Error, contentDescription = null)
                         } else {
                             IconButton(onClick = { textFieldValue = TextFieldValue("") }) {
@@ -77,7 +79,12 @@ fun EditTextPreferenceWidget(
                             }
                         }
                     },
-                    isError = textFieldValue.text.isBlank() && !canBeBlank,
+                    supportingText = {
+                        if (!validate(textFieldValue.text) && errorMessage != null) {
+                            Text(errorMessage(textFieldValue.text))
+                        }
+                    },
+                    isError = (textFieldValue.text.isBlank() && !canBeBlank) || !validate(textFieldValue.text),
                     singleLine = singleLine,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -87,7 +94,9 @@ fun EditTextPreferenceWidget(
             ),
             confirmButton = {
                 TextButton(
-                    enabled = textFieldValue.text != value && (textFieldValue.text.isNotBlank() || canBeBlank),
+                    enabled =
+                    textFieldValue.text != value && (textFieldValue.text.isNotBlank() || canBeBlank) &&
+                        validate(textFieldValue.text),
                     onClick = {
                         scope.launch {
                             if (onConfirm(textFieldValue.text)) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/TrackSelect.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/TrackSelect.kt
@@ -18,19 +18,19 @@ class TrackSelect(
             subtitlePreferences.preferredSubLanguages().get()
         } else {
             audioPreferences.preferredAudioLanguages().get()
-        }.split(",").filter { it.isNotEmpty() }
+        }.split(",").filter(String::isNotEmpty).map(String::trim)
 
         val whitelist = if (subtitle) {
             subtitlePreferences.subtitleWhitelist().get()
         } else {
             ""
-        }.split(",").filter { it.isNotEmpty() }
+        }.split(",").filter(String::isNotEmpty).map(String::trim)
 
         val blacklist = if (subtitle) {
             subtitlePreferences.subtitleBlacklist().get()
         } else {
             ""
-        }.split(",").filter { it.isNotEmpty() }
+        }.split(",").filter(String::isNotEmpty).map(String::trim)
 
         val locales = prefLangs.map(::Locale).ifEmpty {
             listOf(LocaleListCompat.getDefault()[0]!!)

--- a/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
@@ -48,4 +48,5 @@ val migrations: List<Migration>
         VideoOrientationMigration(),
         PEMFileMigration(),
         CategoryPreferencesCleanupMigration(),
+        PrefLangMigration(),
     )

--- a/app/src/main/java/mihon/core/migration/migrations/PrefLangMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/PrefLangMigration.kt
@@ -1,0 +1,54 @@
+package mihon.core.migration.migrations
+
+import android.app.Application
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import eu.kanade.tachiyomi.ui.player.settings.AudioPreferences
+import eu.kanade.tachiyomi.ui.player.settings.SubtitlePreferences
+import mihon.core.migration.Migration
+import mihon.core.migration.MigrationContext
+import java.util.Locale
+import java.util.MissingResourceException
+import kotlin.text.split
+
+class PrefLangMigration : Migration {
+    override val version = 130f
+
+    override suspend fun invoke(migrationContext: MigrationContext): Boolean {
+        val context = migrationContext.get<Application>() ?: return false
+        val audioPreferences = migrationContext.get<AudioPreferences>() ?: return false
+        val subtitlePreferences = migrationContext.get<SubtitlePreferences>() ?: return false
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+
+        listOf(
+            audioPreferences.preferredAudioLanguages(),
+            subtitlePreferences.preferredSubLanguages(),
+        ).forEach { pref ->
+            if (pref.isSet()) {
+                prefs.edit {
+                    val langs = prefs.getString(
+                        pref.key(),
+                        "",
+                    )!!.split(",").filter(String::isNotEmpty).map(String::trim)
+                    val newLangs = langs.filter { it.isValidCode() }.joinToString(",")
+                    putString(pref.key(), newLangs)
+                }
+            }
+        }
+
+        return true
+    }
+
+    private fun String.isValidCode(): Boolean {
+        try {
+            val locale = Locale(this)
+            if (locale.isO3Language == locale.language && locale.language == locale.getDisplayName(Locale.ENGLISH)) {
+                return false
+            }
+        } catch (_: MissingResourceException) {
+            return false
+        }
+
+        return true
+    }
+}

--- a/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
@@ -154,6 +154,7 @@
     <string name="pref_player_subtitle_summary">Preferred languages, whitelist, blacklist</string>
     <string name="pref_player_subtitle_lang">Preferred languages</string>
     <string name="pref_player_subtitle_lang_info">Subtitle language(s) to be selected by default on a video with multiple subtitles, Two- or three-letter languages codes work. Multiple values can be delimited by a comma.</string>
+    <string name="pref_player_subtitle_invalid_lang">Invalid code: \"%s\"</string>
     <string name="pref_player_subtitle_whitelist">Whitelist</string>
     <string name="pref_player_subtitle_whitelist_info">Whitelist for subtitles. If a whitelist is defined, the first subtitle that contains a whitelisted word will be used. Multiple values can be delimited by a comma.</string>
     <string name="pref_player_subtitle_blacklist">Blacklist</string>


### PR DESCRIPTION
Fixes the issue of people entering invalid codes to settings, as well as adding a migration to clean up any existing settings.
