### PR TITLE
feat(downloader): Use async execution of ffmpeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Fixed
+
+- Fix stop/continue anime download button ([@Secozzi](https://github.com/Secozzi)) ([#2099](https://github.com/aniyomiorg/aniyomi/pull/2099))
+
 ### Added
 
 - Add player settings to the main settings screen ([@jmir1](https://github.com/jmir1)) ([#2081](https://github.com/aniyomiorg/aniyomi/pull/2081))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadNotifier.kt
@@ -83,7 +83,7 @@ internal class AnimeDownloadNotifier(private val context: Context) {
                 // Pause action
                 addAction(
                     R.drawable.ic_pause_24dp,
-                    context.stringResource(MR.strings.action_pause),
+                    context.stringResource(AYMR.strings.action_stop),
                     NotificationReceiver.pauseAnimeDownloadsPendingBroadcast(context),
                 )
                 addAction(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadsTab.kt
@@ -167,7 +167,7 @@ data object DownloadsTab : Tab {
             floatingActionButton = {
                 AnimatedVisibility(
                     visible = when (state.currentPage) {
-                        0 -> false
+                        0 -> animeDownloadList.isNotEmpty()
                         1 -> mangaDownloadList.isNotEmpty()
                         else -> false
                     },
@@ -180,9 +180,9 @@ data object DownloadsTab : Tab {
                         text = {
                             val id = when (state.currentPage) {
                                 0 -> if (animeIsRunning) {
-                                    MR.strings.action_pause
+                                    AYMR.strings.action_stop
                                 } else {
-                                    MR.strings.action_resume
+                                    AYMR.strings.action_continue
                                 }
                                 1 -> if (mangaIsRunning) {
                                     MR.strings.action_pause

--- a/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
@@ -7,6 +7,8 @@
     <string name="action_display_unseen_badge">Unseen episodes</string>
     <string name="action_reorganize_by">Reorder</string>
     <string name="relative_time_now">Now</string>
+    <string name="action_stop">Stop</string>
+    <string name="action_continue">Continue</string>
 
     <!-- Changed from mihon -->
     <string name="manga">Manga</string>


### PR DESCRIPTION
Closes #2086

Use async execution of ffmpeg for easier handling of cancellations. Adds back pause/resume button, but with a changed name to better reflect what it actually does.
