### PR TITLE
fix: ext lib 16 parameter addition fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 ### Fixed
 
+- Fix list view resetting scroll upon exiting child ([@quickdesh](https://github.com/quickdesh)) ([#1982](https://github.com/aniyomiorg/aniyomi/pull/1982))
 - Fix episode number parsing ([@Secozzi](https://github.com/Secozzi)) ([#2096](https://github.com/aniyomiorg/aniyomi/pull/2096))
 - Fix tracking menu not opening on add to library ([@Secozzi](https://github.com/Secozzi)) ([#2098](https://github.com/aniyomiorg/aniyomi/pull/2098))
 - Fix stop/continue anime download button ([@Secozzi](https://github.com/Secozzi)) ([#2099](https://github.com/aniyomiorg/aniyomi/pull/2099))
@@ -20,6 +21,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Added
 
+- Add support for new parameters from ext lib 16 ([@quickdesh](https://github.com/quickdesh)) ([#1982](https://github.com/aniyomiorg/aniyomi/pull/1982))
 - Add player settings to the main settings screen ([@jmir1](https://github.com/jmir1)) ([#2081](https://github.com/aniyomiorg/aniyomi/pull/2081))
 - Add seasons support ([@Secozzi](https://github.com/Secozzi)) ([#2095](https://github.com/aniyomiorg/aniyomi/pull/2095))
 

--- a/app/src/main/java/eu/kanade/domain/entries/anime/model/Anime.kt
+++ b/app/src/main/java/eu/kanade/domain/entries/anime/model/Anime.kt
@@ -33,7 +33,8 @@ val Anime.seasonDownloadedFilter: TriState
 fun Anime.episodesFiltered(): Boolean {
     return unseenFilter != TriState.DISABLED ||
         downloadedFilter != TriState.DISABLED ||
-        bookmarkedFilter != TriState.DISABLED
+        bookmarkedFilter != TriState.DISABLED ||
+        fillermarkedFilter != TriState.DISABLED
 }
 
 fun Anime.seasonsFiltered(): Boolean {

--- a/domain/src/main/java/tachiyomi/domain/entries/anime/model/Anime.kt
+++ b/domain/src/main/java/tachiyomi/domain/entries/anime/model/Anime.kt
@@ -104,9 +104,15 @@ data class Anime(
         return episodeFlags and EPISODE_SORT_DIR_MASK == EPISODE_SORT_DESC
     }
 
+    val showPreviewsRaw: Long
+        get() = episodeFlags and EPISODE_PREVIEWS_MASK
+
     fun showPreviews(): Boolean {
         return episodeFlags and EPISODE_PREVIEWS_MASK == EPISODE_SHOW_PREVIEWS
     }
+
+    val showSummariesRaw: Long
+        get() = episodeFlags and EPISODE_SUMMARIES_MASK
 
     fun showSummaries(): Boolean {
         return episodeFlags and EPISODE_SUMMARIES_MASK == EPISODE_SHOW_SUMMARIES

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -242,6 +242,8 @@ class LibraryPreferences(
         sortEpisodeByAscendingOrDescending().set(
             if (anime.sortDescending()) Anime.EPISODE_SORT_DESC else Anime.EPISODE_SORT_ASC,
         )
+        showEpisodeThumbnailPreviews().set(anime.showPreviewsRaw)
+        showEpisodeSummaries().set(anime.showSummariesRaw)
     }
 
     fun setChapterSettingsDefault(manga: Manga) {


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
Changes
---
- Fixed setting default settings for the ext lib 16 parameters
- Fixed filtering of fillermarked items
- Added changelog for #1982
- Used wrong commit name by accident (for first commit)