### PR TITLE
fix: Prevent redirection to specific URL schemes

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
@@ -115,7 +115,7 @@ fun WebViewScreenContent(
                     }
 
                     val ignoreUriSchema = listOf("intent://", "market://", "data:text/html")
-                    if(ignoreUriSchema.any { schema -> it.url.toString().startsWith(schema)}) {
+                    if (ignoreUriSchema.any { schema -> it.url.toString().startsWith(schema) }) {
                         return true
                     }
 

--- a/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
@@ -114,8 +114,8 @@ fun WebViewScreenContent(
                         return false
                     }
 
-                    // Ignore intents urls
-                    if (it.url.toString().startsWith("intent://")) {
+                    val ignoreUriSchema = listOf("intent://", "market://", "data:text/html")
+                    if(ignoreUriSchema.any { schema -> it.url.toString().startsWith(schema)}) {
                         return true
                     }
 


### PR DESCRIPTION
Adds a check to ignore the following protocols in WebView:

- market://: Used for [deep-linking to the Google Play Store](https://developer.android.com/distribute/marketing-tools/linking-to-google-play?hl=en#UriSummary) (AliExpress, Amazon, ...)
- data:text/: Embedded HTML/Scripts often used for ad tracking or WebRTC fingerprinting. 
    Ex.:
    ```
    data:text/html;charset=utf8,<html><head><script>RTCPeerConnection.generateCertificate({name: "ECDSA", namedCurve: "P-256"})["then"](function(cert){window.parent.postMessage(cert, "*")})</script></head></html>
    ```

The Webview redirects these URLs to a blank page. The goal is to improve the WebView's usability