### PR TITLE
Fix MAL anime tracking: duplicate query param and wrong list endpoint

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -102,7 +102,6 @@ class MyAnimeListApi(
             val url = "$BASE_API_URL/anime".toUri().buildUpon()
                 // MAL API throws a 400 when the query is over 64 characters...
                 .appendQueryParameter("q", query.take(64))
-                .appendQueryParameter("q", query)
                 .appendQueryParameter("nsfw", "true")
                 .build()
             with(json) {
@@ -304,7 +303,7 @@ class MyAnimeListApi(
 
     suspend fun findListItemsAnime(query: String, offset: Int = 0): List<AnimeTrackSearch> {
         return withIOContext {
-            val myListSearchResult = getListPage(offset)
+            val myListSearchResult = getListPage(offset, "animelist")
 
             val matches = myListSearchResult.data
                 .filter { it.node.title.contains(query, ignoreCase = true) }
@@ -320,9 +319,9 @@ class MyAnimeListApi(
         }
     }
 
-    private suspend fun getListPage(offset: Int): MALUserSearchResult {
+    private suspend fun getListPage(offset: Int, listType: String = "mangalist"): MALUserSearchResult {
         return withIOContext {
-            val urlBuilder = "$BASE_API_URL/users/@me/mangalist".toUri().buildUpon()
+            val urlBuilder = "$BASE_API_URL/users/@me/$listType".toUri().buildUpon()
                 .appendQueryParameter("fields", "list_status{start_date,finish_date}")
                 .appendQueryParameter("limit", LIST_PAGINATION_AMOUNT.toString())
             if (offset > 0) {


### PR DESCRIPTION
## Summary

- **Remove duplicate `q` parameter in `searchAnime()`** that overwrites the truncated (64 char) query and causes HTTP 400 errors from the MAL API for long anime titles
- **Fix `findListItemsAnime()` querying `/mangalist` instead of `/animelist`** by adding a `listType` parameter to `getListPage()`, so anime list searches hit the correct endpoint

## Bug details

### Bug 1: Duplicate `q` parameter in `searchAnime()`

The `q` query parameter is appended twice: first truncated to 64 characters (as intended), then again with the full query. The second value overwrites the first, defeating the truncation and causing a 400 error from the MAL API. The equivalent `search()` method for manga does not have this issue.

### Bug 2: `findListItemsAnime()` queries the wrong endpoint

`getListPage()` hardcodes the endpoint to `/users/@me/mangalist`. This method is called by both `findListItems()` (manga) and `findListItemsAnime()` (anime), so anime list searches hit the wrong endpoint and return no results or incorrect results.

## Steps to reproduce

**Bug 1:** Track an anime with a title longer than 64 characters → search fails with HTTP 400.

**Bug 2:** Try to bind an anime entry from your MAL anime list → returns no results because it searches the manga list.

## Expected behavior

**Bug 1:** The query should be truncated to 64 characters before being sent to the MAL API, just like the manga `search()` method already does.

**Bug 2:** `findListItemsAnime()` should query `/users/@me/animelist` and return matching anime results.

## Test plan

- [x] Search for an anime with a title longer than 64 characters on MAL tracker
- [x] Verify search returns results without HTTP 400
- [x] Bind an anime from MAL anime list
- [x] Verify anime list search returns correct anime results

