### PR TITLE
Add AMOLED toggle to onboarding

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/model/ThemeMode.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/model/ThemeMode.kt
@@ -8,6 +8,8 @@ enum class ThemeMode {
     SYSTEM,
 }
 
+fun ThemeMode.supportsAmoled(): Boolean = this != ThemeMode.LIGHT
+
 fun setAppCompatDelegateThemeMode(themeMode: ThemeMode) {
     AppCompatDelegate.setDefaultNightMode(
         when (themeMode) {

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/ThemeStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/ThemeStep.kt
@@ -1,12 +1,16 @@
 package eu.kanade.presentation.more.onboarding
 
+import android.app.Activity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.setAppCompatDelegateThemeMode
 import eu.kanade.presentation.more.settings.widget.AppThemeModePreferenceWidget
 import eu.kanade.presentation.more.settings.widget.AppThemePreferenceWidget
+import eu.kanade.presentation.more.settings.widget.ThemeDarkAmoledPreferenceWidget
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -19,6 +23,8 @@ internal class ThemeStep : OnboardingStep {
 
     @Composable
     override fun Content() {
+        val context = LocalContext.current
+
         val themeModePref = uiPreferences.themeMode()
         val themeMode by themeModePref.collectAsState()
 
@@ -41,6 +47,15 @@ internal class ThemeStep : OnboardingStep {
                 value = appTheme,
                 amoled = amoled,
                 onItemClick = { appThemePref.set(it) },
+            )
+
+            ThemeDarkAmoledPreferenceWidget(
+                value = amoled,
+                themeMode = themeMode,
+                onValueChange = {
+                    amoledPref.set(it)
+                    (context as? Activity)?.let(ActivityCompat::recreate)
+                },
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -20,6 +20,7 @@ import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.presentation.more.settings.screen.appearance.AppLanguageScreen
 import eu.kanade.presentation.more.settings.widget.AppThemeModePreferenceWidget
 import eu.kanade.presentation.more.settings.widget.AppThemePreferenceWidget
+import eu.kanade.presentation.more.settings.widget.ThemeDarkAmoledPreferenceWidget
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableMap
@@ -85,15 +86,18 @@ object SettingsAppearanceScreen : SearchableSettings {
                         )
                     }
                 },
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = amoledPref,
+                Preference.PreferenceItem.CustomPreference(
                     title = stringResource(MR.strings.pref_dark_theme_pure_black),
-                    enabled = themeMode != ThemeMode.LIGHT,
-                    onValueChanged = {
-                        (context as? Activity)?.let { ActivityCompat.recreate(it) }
-                        true
-                    },
-                ),
+                ) {
+                    ThemeDarkAmoledPreferenceWidget(
+                        value = amoled,
+                        themeMode = themeMode,
+                        onValueChange = {
+                            amoledPref.set(it)
+                            (context as? Activity)?.let(ActivityCompat::recreate)
+                        },
+                    )
+                },
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/ThemeDarkAmoledPreferenceWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/ThemeDarkAmoledPreferenceWidget.kt
@@ -1,0 +1,31 @@
+package eu.kanade.presentation.more.settings.widget
+
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import eu.kanade.domain.ui.model.ThemeMode
+import eu.kanade.domain.ui.model.supportsAmoled
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+internal fun ThemeDarkAmoledPreferenceWidget(
+    value: Boolean,
+    themeMode: ThemeMode,
+    onValueChange: (Boolean) -> Unit,
+) {
+    BasePreferenceWidget(
+        title = stringResource(MR.strings.pref_dark_theme_pure_black),
+        onClick = {
+            if (themeMode.supportsAmoled()) {
+                onValueChange(!value)
+            }
+        },
+        widget = {
+            Switch(
+                checked = value,
+                enabled = themeMode.supportsAmoled(),
+                onCheckedChange = onValueChange,
+            )
+        },
+    )
+}

--- a/app/src/test/java/eu/kanade/domain/ui/model/ThemeModeTest.kt
+++ b/app/src/test/java/eu/kanade/domain/ui/model/ThemeModeTest.kt
@@ -1,0 +1,23 @@
+package eu.kanade.domain.ui.model
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ThemeModeTest {
+
+    @Test
+    fun `amoled option is unavailable in light mode`() {
+        assertFalse(ThemeMode.LIGHT.supportsAmoled())
+    }
+
+    @Test
+    fun `amoled option is available in dark mode`() {
+        assertTrue(ThemeMode.DARK.supportsAmoled())
+    }
+
+    @Test
+    fun `amoled option is available in system mode`() {
+        assertTrue(ThemeMode.SYSTEM.supportsAmoled())
+    }
+}


### PR DESCRIPTION
Summary:
- add a reusable AMOLED dark preference widget
- expose the pure black toggle during onboarding
- share the same AMOLED handling path between onboarding and appearance settings
- add a small unit test for ThemeMode AMOLED eligibility

Notes:
- this change does not add a brand new theme engine; it exposes the existing AMOLED/pure-black support earlier in the user flow