### PR TITLE
fix(player): Short-press speed button no longer overwrites default speed preference

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/BottomLeftPlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/BottomLeftPlayerControls.kt
@@ -68,7 +68,6 @@ fun BottomLeftPlayerControls(
             onClick = {
                 val newSpeed = if (playbackSpeed >= 2) 0.25f else playbackSpeed + 0.25f
                 onPlaybackSpeedChange(newSpeed)
-                playerPreferences.playerSpeed().set(newSpeed)
             },
             onLongClick = { onOpenSheet(Sheets.PlaybackSpeed) },
         )


### PR DESCRIPTION
Fixes #2311

### What changed
Removed the `playerPreferences.playerSpeed().set(newSpeed)` call from the short-press speed button handler.

### Why
Short-pressing the speed button cycles through speeds in +0.25 increments as a temporary in-session adjustment. This call was silently persisting whatever speed the user landed on as the default player speed, overwriting any value previously saved via the explicit "make default speed" button in the long-press sheet.

### Tested
Confirmed on emulator (Pixel 7, API 35):
- Short-press cycles speed correctly
- Default speed set via long-press → "make default speed" now persists correctly after app restart

### Notes
`./gradlew lint` reports 30 errors / 51 warnings, all pre-existing issues in auto-generated translation files (`i18n-aniyomi/build/generated/`). No new lint issues introduced by this change.