### PR TITLE
feat(player): Short-press speed button cycles through user-defined speed presets

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/BottomLeftPlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/BottomLeftPlayerControls.kt
@@ -66,9 +66,17 @@ fun BottomLeftPlayerControls(
         ControlsButton(
             text = stringResource(AYMR.strings.player_speed, playbackSpeed),
             onClick = {
-                val newSpeed = if (playbackSpeed >= 2) 0.25f else playbackSpeed + 0.25f
+                val presets = playerPreferences.speedPresets().get()
+                    .map { it.toFloat() }
+                    .sorted()
+
+                val newSpeed = if (presets.isEmpty()) {
+                    if (playbackSpeed >= 2f) 0.25f else playbackSpeed + 0.25f
+                } else {
+                    val currentIndex = presets.indexOfFirst { kotlin.math.abs(it - playbackSpeed) < 0.001f }
+                    presets[(currentIndex + 1) % presets.size]
+                }
                 onPlaybackSpeedChange(newSpeed)
-                playerPreferences.playerSpeed().set(newSpeed)
             },
             onLongClick = { onOpenSheet(Sheets.PlaybackSpeed) },
         )


### PR DESCRIPTION
Closes #2312

### What changed
The short-press speed button `onClick` handler now cycles through the user's configured speed presets (`playerPreferences.speedPresets()`) instead of hardcoded +0.25 increments between 0.25 and 2.0.

### Why
The preferred speed presets list (configurable via long-press → playback speed sheet) had no functional use beyond selecting a one-off speed. Short-pressing the button now makes use of that list, giving users a fully customisable cycle of speeds.

The fallback to the old +0.25 increment behaviour is preserved for the edge case where the preset list is empty.

### Behaviour
- Short-press cycles through presets in ascending order, wrapping around to the first after the last
- If current speed is not in the preset list, the next press jumps to the first preset
- Long-press still opens the playback speed sheet to configure presets and set default speed

### Tested
Confirmed on emulator (Pixel 7, API 35):
- Custom preset list (e.g. 0.75, 1.0, 1.5, 2.0) cycles correctly on short-press
- Wrap-around from last to first preset works correctly
- Fallback behaviour works when all presets are removed

### Notes
- Also incorporates the fix from #2317 (removes implicit default speed overwrite on short-press).