### PR TITLE
fix(UI): Tracker date selector is now scrollable in landscape mode

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogSelector.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogSelector.kt
@@ -13,8 +13,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -158,7 +160,9 @@ fun TrackDateSelector(
         modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars),
         title = { Text(text = title) },
         content = {
-            Column {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+            ) {
                 DatePicker(
                     state = pickerState,
                     title = null,


### PR DESCRIPTION
Fixes #2290

## Problem before
`TrackDateSelector` displayed the calendar (`DatePicker`) and Remove/Cancel/OK buttons inside a non-scrollable `Column`, so the calendar and buttons could exceed the available height in landscape mode.

## What changed
Added vertical scrolling to the content `Column` in `TrackDateSelector`

## Testing
Tested on Pixel 7 API 35 emulator with:
- Portrait and landscape orientations
- Maximum font size
- Maximum display size
- Empty date state
- Existing date state with Remove button visible

The date picker calendar remains usable and Remove, Cancel, OK buttons are working correctly.

### Images
| Before | When scrolled down |
| ------- | ------- |
| ![](https://github.com/user-attachments/assets/b7220d87-609e-471a-82e0-b8516926ee03) | ![](https://github.com/user-attachments/assets/8c1449ac-02e8-4c78-9391-12600db1a75d) |
