### PR TITLE
fix(AnimeScreen): skip episode thumbnail regeneration on refresh

### DIFF
--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
@@ -260,7 +260,7 @@ actual class LocalAnimeSource(
                     }
 
                     // Generate the preview from the episode if not available
-                    if (this.preview_url == null) {
+                    if (thumbnailManager.find(anime.url, "${this.name}-${DEFAULT_THUMBNAIL_NAME}") == null) {
                         try {
                             val tempFileSuffix = anime.title + this.name + DEFAULT_THUMBNAIL_NAME
                             val updateThumbnail: (InputStream) -> Unit = { thumbnailManager.update(anime, this, it) }

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalEpisodeThumbnailManager.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalEpisodeThumbnailManager.kt
@@ -19,8 +19,8 @@ actual class LocalEpisodeThumbnailManager(
 
     actual fun find(animeUrl: String, fileName: String): UniFile? {
         return fileSystem.getFilesInAnimeDirectory(animeUrl)
-            // Get all file whose names contain the episode name and the word 'thumbnail'
-            .filter { it.isFile && it.nameWithoutExtension.equals(fileName, ignoreCase = true) }
+            // Get all file whose names match the episode name with the DEFAULT_THUMBNAIL_NAME suffix
+            .filter { it.isFile && it.name.equals(fileName, ignoreCase = true) }
             // Get the first actual image
             .firstOrNull { ImageUtil.isImage(it.name) { it.openInputStream() } }
     }


### PR DESCRIPTION
Fixes #2182

Related to #2202 and #2295

## Problem before
Local anime episode thumbnails were regenerated every time the anime details page was refreshed, even when matching thumbnail files already existed. This caused unnecessary FFmpeg work, delayed episode list loading, and overwrote existing generated or user-provided episode thumbnail files.

The issue was caused by two things:
- `getEpisodeList()` only checked `preview_url` before generating episode thumbnails, but `SEpisode` objects are recreated there and `preview_url` was never populated first.
- `LocalEpisodeThumbnailManager.find()` compared `nameWithoutExtension` (`[episode_name]-thumbnail`) against a full filename (`[episode_name]-thumbnail.jpg`), so existing thumbnail files were not matched correctly.

## What changed
- Changed `LocalEpisodeThumbnailManager.find()` to compare the expected full thumbnail filename with the file's full name.
- Changed `getEpisodeList()` to skip thumbnail generation when a matching episode thumbnail file already exists in the anime directory.

## Testing
Tested on a Pixel 7 API 35 emulator with local anime directories containing episode video files and existing thumbnail files.

Test cases:
- Directory with `EP1.mkv`, `EP2.mkv` and no episode thumbnails: thumbnails are generated once.
- Refreshing the anime details page after thumbnails already exist: thumbnails are not regenerated.
- Directory with pre-existing `EP1-thumbnail.jpg`: the existing thumbnail is reused and not overwritten.
- Directory with custom `cover.jpg` and existing episode thumbnails: `cover.jpg` and episode thumbnails are not regenerated on refresh.