### PR TITLE
fix(downloader): fix HLS audio desync when muxing external audio tracks

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
@@ -611,6 +611,7 @@ class AnimeDownloader(
             "-map 0:v", audioMaps, "-map 0:a?", subtitleMaps, "-map 0:s? -map 0:t?",
             "-f matroska -c:a copy -c:v copy -c:s copy",
             subtitleMetadata, audioMetadata, sourceVideoOptions,
+            "-avoid_negative_ts make_zero",
             "\"$ffmpegFilename\" -y",
         )
             .filter(String::isNotBlank)


### PR DESCRIPTION
## Problem

Downloading an HLS episode with a separate audio track (`video.audioTracks`
non-empty) produces a file where:

- Audio is delayed ~15 s relative to video
- Total duration is longer than the actual episode

Each `-i` input to ffmpeg carries its own MPEG-TS PTS baseline.
When muxed with `-c copy`, the PTS difference is preserved in the
container, causing the apparent desync.

## Fix

Add `-avoid_negative_ts make_zero` to `getFFmpegOptions` before the
output filename. This shifts all stream timestamps so the minimum PTS
across all inputs becomes zero, aligning video and audio without
re-encoding either stream. No behavioral change for downloads without
external audio tracks.