### PR TITLE
feat: Add landscape thumbnail toggle for anime library

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryComfortableGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryComfortableGrid.kt
@@ -20,6 +20,7 @@ import tachiyomi.domain.library.anime.LibraryAnime
 internal fun AnimeLibraryComfortableGrid(
     items: List<AnimeLibraryItem>,
     columns: Int,
+    useLandscapeThumbnails: Boolean,
     contentPadding: PaddingValues,
     selection: List<LibraryAnime>,
     onClick: (LibraryAnime) -> Unit,
@@ -43,6 +44,7 @@ internal fun AnimeLibraryComfortableGrid(
             EntryComfortableGridItem(
                 isSelected = selection.fastAny { it.id == libraryItem.libraryAnime.id },
                 title = anime.title,
+                useLandscapeThumbnails = useLandscapeThumbnails,
                 coverData = AnimeCover(
                     animeId = anime.id,
                     sourceId = anime.source,

--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryCompactGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryCompactGrid.kt
@@ -21,6 +21,7 @@ fun AnimeLibraryCompactGrid(
     items: List<AnimeLibraryItem>,
     showTitle: Boolean,
     columns: Int,
+    useLandscapeThumbnails: Boolean,
     contentPadding: PaddingValues,
     selection: List<LibraryAnime>,
     onClick: (LibraryAnime) -> Unit,
@@ -44,6 +45,7 @@ fun AnimeLibraryCompactGrid(
             EntryCompactGridItem(
                 isSelected = selection.fastAny { it.id == libraryItem.libraryAnime.id },
                 title = anime.title.takeIf { showTitle },
+                useLandscapeThumbnails = useLandscapeThumbnails,
                 coverData = AnimeCover(
                     animeId = anime.id,
                     sourceId = anime.source,

--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryContent.kt
@@ -44,6 +44,7 @@ fun AnimeLibraryContent(
     onGlobalSearchClicked: () -> Unit,
     getNumberOfAnimeForCategory: (Category) -> Int?,
     getDisplayMode: (Int) -> PreferenceMutableState<LibraryDisplayMode>,
+    getLandscapeThumbnails: () -> PreferenceMutableState<Boolean>,
     getColumnsForOrientation: (Boolean) -> PreferenceMutableState<Int>,
     getAnimeLibraryForPage: (Int) -> List<AnimeLibraryItem>,
 ) {
@@ -104,6 +105,7 @@ fun AnimeLibraryContent(
                 searchQuery = searchQuery,
                 onGlobalSearchClicked = onGlobalSearchClicked,
                 getDisplayMode = getDisplayMode,
+                getLandscapeThumbnails = getLandscapeThumbnails,
                 getColumnsForOrientation = getColumnsForOrientation,
                 getLibraryForPage = getAnimeLibraryForPage,
                 onClickAnime = onClickAnime,

--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryPager.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryPager.kt
@@ -37,6 +37,7 @@ fun AnimeLibraryPager(
     searchQuery: String?,
     onGlobalSearchClicked: () -> Unit,
     getDisplayMode: (Int) -> PreferenceMutableState<LibraryDisplayMode>,
+    getLandscapeThumbnails: () -> PreferenceMutableState<Boolean>,
     getColumnsForOrientation: (Boolean) -> PreferenceMutableState<Int>,
     getLibraryForPage: (Int) -> List<AnimeLibraryItem>,
     onClickAnime: (LibraryAnime) -> Unit,
@@ -69,6 +70,7 @@ fun AnimeLibraryPager(
             }
 
             val displayMode by getDisplayMode(page)
+            val landscapeThumbnails by getLandscapeThumbnails()
             val configuration = LocalConfiguration.current
             val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
             val columns by remember(isLandscape) { getColumnsForOrientation(isLandscape) }
@@ -94,6 +96,7 @@ fun AnimeLibraryPager(
                         items = library,
                         showTitle = displayMode is LibraryDisplayMode.CompactGrid,
                         columns = columns,
+                        useLandscapeThumbnails = landscapeThumbnails,
                         contentPadding = contentPadding,
                         selection = selectedAnime,
                         onClick = onClickAnime,
@@ -108,6 +111,7 @@ fun AnimeLibraryPager(
                     AnimeLibraryComfortableGrid(
                         items = library,
                         columns = columns,
+                        useLandscapeThumbnails = landscapeThumbnails,
                         contentPadding = contentPadding,
                         selection = selectedAnime,
                         onClick = onClickAnime,

--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibrarySettingsDialog.kt
@@ -284,6 +284,11 @@ private fun ColumnScope.DisplayPage(
         )
     }
 
+    CheckboxItem(
+        label = stringResource(AYMR.strings.action_display_landscape_thumbnails_anime),
+        pref = screenModel.libraryPreferences.animeLandscapeThumbnails(),
+    )
+
     HeadingItem(MR.strings.overlay_header)
     CheckboxItem(
         label = stringResource(AYMR.strings.action_display_download_badge_anime),

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonEntryItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonEntryItem.kt
@@ -76,6 +76,7 @@ fun EntryCompactGridItem(
     onLongClick: () -> Unit,
     isSelected: Boolean = false,
     title: String? = null,
+    useLandscapeThumbnails: Boolean = false,
     onClickContinueViewing: (() -> Unit)? = null,
     coverAlpha: Float = 1f,
     coverBadgeStart: @Composable (RowScope.() -> Unit)? = null,
@@ -87,13 +88,16 @@ fun EntryCompactGridItem(
         onLongClick = onLongClick,
     ) {
         EntryGridCover(
+            useLandscapeThumbnails = useLandscapeThumbnails,
             cover = {
-                ItemCover.Book(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .alpha(if (isSelected) GRID_SELECTED_COVER_ALPHA else coverAlpha),
-                    data = coverData,
-                )
+                val coverModifier = Modifier
+                    .fillMaxWidth()
+                    .alpha(if (isSelected) GRID_SELECTED_COVER_ALPHA else coverAlpha)
+                if (useLandscapeThumbnails) {
+                    ItemCover.Thumb(modifier = coverModifier, data = coverData)
+                } else {
+                    ItemCover.Book(modifier = coverModifier, data = coverData)
+                }
             },
             badgesStart = coverBadgeStart,
             badgesEnd = coverBadgeEnd,
@@ -183,6 +187,7 @@ fun EntryComfortableGridItem(
     titleMaxLines: Int = 2,
     coverData: EntryCoverModel,
     coverAlpha: Float = 1f,
+    useLandscapeThumbnails: Boolean = false,
     coverBadgeStart: (@Composable RowScope.() -> Unit)? = null,
     coverBadgeEnd: (@Composable RowScope.() -> Unit)? = null,
     onClickContinueViewing: (() -> Unit)? = null,
@@ -194,13 +199,16 @@ fun EntryComfortableGridItem(
     ) {
         Column {
             EntryGridCover(
+                useLandscapeThumbnails = useLandscapeThumbnails,
                 cover = {
-                    ItemCover.Book(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .alpha(if (isSelected) GRID_SELECTED_COVER_ALPHA else coverAlpha),
-                        data = coverData,
-                    )
+                    val coverModifier = Modifier
+                        .fillMaxWidth()
+                        .alpha(if (isSelected) GRID_SELECTED_COVER_ALPHA else coverAlpha)
+                    if (useLandscapeThumbnails) {
+                        ItemCover.Thumb(modifier = coverModifier, data = coverData)
+                    } else {
+                        ItemCover.Book(modifier = coverModifier, data = coverData)
+                    }
                 },
                 badgesStart = coverBadgeStart,
                 badgesEnd = coverBadgeEnd,
@@ -234,6 +242,7 @@ fun EntryComfortableGridItem(
 @Composable
 private fun EntryGridCover(
     modifier: Modifier = Modifier,
+    useLandscapeThumbnails: Boolean = false,
     cover: @Composable BoxScope.() -> Unit = {},
     badgesStart: (@Composable RowScope.() -> Unit)? = null,
     badgesEnd: (@Composable RowScope.() -> Unit)? = null,
@@ -242,7 +251,7 @@ private fun EntryGridCover(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .aspectRatio(ItemCover.Book.ratio),
+            .aspectRatio(if (useLandscapeThumbnails) ItemCover.Thumb.ratio else ItemCover.Book.ratio),
     ) {
         cover()
         content?.invoke(this)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryScreenModel.kt
@@ -580,6 +580,10 @@ class AnimeLibraryScreenModel(
         return libraryPreferences.displayMode().asState(screenModelScope)
     }
 
+    fun getLandscapeThumbnails(): PreferenceMutableState<Boolean> {
+        return libraryPreferences.animeLandscapeThumbnails().asState(screenModelScope)
+    }
+
     fun getColumnsPreferenceForCurrentOrientation(isLandscape: Boolean): PreferenceMutableState<Int> {
         return (
             if (isLandscape) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryTab.kt
@@ -223,6 +223,7 @@ data object AnimeLibraryTab : Tab {
                         },
                         getNumberOfAnimeForCategory = { state.getAnimeCountForCategory(it) },
                         getDisplayMode = { screenModel.getDisplayMode() },
+                        getLandscapeThumbnails = { screenModel.getLandscapeThumbnails() },
                         getColumnsForOrientation = {
                             screenModel.getColumnsPreferenceForCurrentOrientation(
                                 it,

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -105,6 +105,8 @@ class LibraryPreferences(
     fun animeLandscapeColumns() = preferenceStore.getInt("pref_animelib_columns_landscape_key", 0)
     fun mangaLandscapeColumns() = preferenceStore.getInt("pref_library_columns_landscape_key", 0)
 
+    fun animeLandscapeThumbnails() = preferenceStore.getBoolean("pref_animelib_landscape_thumbnails", false)
+
     // Mixture Filter
 
     fun filterDownloadedAnime() =

--- a/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
@@ -423,6 +423,7 @@
     <string name="action_display_download_badge_anime">Downloaded episodes</string>
     <string name="action_display_show_continue_watching_button">Continue watching button</string>
     <string name="action_display_grid_mode">Grid display mode</string>
+    <string name="action_display_landscape_thumbnails_anime">Landscape thumbnails</string>
     <string name="action_display_local_badge_manga">Local manga</string>
     <string name="action_display_local_badge_anime">Local anime</string>
     <string name="pref_search_pinned_manga_sources_only">Only search pinned manga sources in global search</string>


### PR DESCRIPTION
Closes #1496.

## Summary

Adds an orthogonal **"Landscape thumbnails"** toggle to the anime library Display settings. When enabled, the library grid renders 16:9 covers (cropped from the source 2:3 poster art via the existing `ContentScale.Crop`) instead of the default 2:3 portrait cards. The toggle composes with the existing display modes — Compact, Comfortable, and Cover-only.

Implementation follows the design steer from @Secozzi in https://github.com/aniyomiorg/aniyomi/issues/1496#issuecomment-4413578332:

| Q | Answer applied |
|---|---|
| **Shape** | Orthogonal boolean toggle (J2K-style), not a 5th `LibraryDisplayMode` |
| **Scope** | Anime library only — Browse / global search / migration untouched |
| **Cropping** | `ContentScale.Crop` (already applied globally in `ItemCover`) |
| **Column count** | Reuses existing `animePortraitColumns()` / `animeLandscapeColumns()` |
| **Title placement** | Inherited from the active display mode (overlay for Compact, below for Comfortable) |

## Notes for review

- **Anime-only by user choice.** The new pref (`animeLandscapeThumbnails()`) lives in shared `LibraryPreferences.kt` but is only wired into the anime screen. Manga wiring would be a trivial follow-up if wanted.
- **`CommonEntryItem` is shared** between anime and manga. The new `useLandscapeThumbnails: Boolean = false` param defaults to `false`, so manga call sites are unaffected.
- **List display mode** is intentionally left untouched (matches Secozzi's "I'm not sure what the plan would be for lists").
- **Q4 from the design discussion** (separate column-count pref for landscape) was dropped in favor of reusing the existing column pref, per the steer.

## Files touched (10)

- `domain/.../LibraryPreferences.kt` — new `animeLandscapeThumbnails()` boolean pref
- `i18n-aniyomi/.../base/strings.xml` — new `action_display_landscape_thumbnails_anime` string
- `AnimeLibrarySettingsDialog.kt` — `CheckboxItem` between display-mode picker and overlay heading
- `AnimeLibraryScreenModel.kt` — `getLandscapeThumbnails()` getter
- `AnimeLibraryTab.kt` → `AnimeLibraryContent.kt` → `AnimeLibraryPager.kt` — pref threaded through
- `AnimeLibraryCompactGrid.kt` + `AnimeLibraryComfortableGrid.kt` — accept + forward the param
- `CommonEntryItem.kt` — three swap sites (Compact body, Comfortable body, `EntryGridCover` `aspectRatio`)

## Test plan

- [ ] Build passes CI
- [ ] Toggle appears under Display tab of anime library settings, below the columns slider
- [ ] Toggling on in Compact mode → covers become 16:9 with title overlay
- [ ] Toggling on in Comfortable mode → covers become 16:9 with title below
- [ ] Toggling on in Cover-only mode → covers become 16:9, no title
- [ ] List mode unaffected
- [ ] Manga library unaffected regardless of toggle state
- [ ] Toggle state persists across app restarts

> Marked as **draft** — happy to iterate on naming, placement, or scope before merge. Screenshots will be added once I get a build off CI.