### PR TITLE
Fix double tap skip duration and player settings crash

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsMainScreen.kt
@@ -76,6 +76,7 @@ class PlayerSettingsMainScreen(private val mainSettings: Boolean) : Screen() {
     @Composable
     fun Content(twoPane: Boolean) {
         val navigator = LocalNavigator.currentOrThrow
+        val items = remember { buildItems() }
         val backPress = LocalBackPress.currentOrThrow
         val containerColor = if (twoPane) getPalerSurface() else MaterialTheme.colorScheme.surface
         val topBarState = rememberTopAppBarState()
@@ -179,7 +180,7 @@ class PlayerSettingsMainScreen(private val mainSettings: Boolean) : Screen() {
         val screen: VoyagerScreen,
     )
 
-    private val items = listOf(
+    private fun buildItems() = listOf(
         Item(
             titleRes = AYMR.strings.pref_player_internal,
             subtitleRes = AYMR.strings.pref_player_internal_summary,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -900,24 +900,24 @@ class PlayerViewModel @JvmOverloads constructor(
         inputMethodManager.toggleSoftInput(InputMethodManager.SHOW_IMPLICIT, 0)
     }
 
-    private val doubleTapToSeekDuration = gesturePreferences.skipLengthPreference().get()
-    private val preciseSeek = gesturePreferences.playerSmoothSeek().get()
-    private val showSeekBar = gesturePreferences.showSeekBar().get()
+    private fun getDoubleTapToSeekDuration() = gesturePreferences.skipLengthPreference().get()
+    private fun getPreciseSeek() = gesturePreferences.playerSmoothSeek().get()
+    private fun getShowSeekBar() = gesturePreferences.showSeekBar().get()
 
     private fun seekToWithText(seekValue: Int, text: String?) {
         _isSeekingForwards.value = seekValue > 0
         _doubleTapSeekAmount.value = seekValue - pos.value.toInt()
         _seekText.update { _ -> text }
-        seekTo(seekValue, preciseSeek)
-        if (showSeekBar) showSeekBar()
+        seekTo(seekValue, getPreciseSeek())
+        if (getShowSeekBar()) showSeekBar()
     }
 
     private fun seekByWithText(value: Int, text: String?) {
         _doubleTapSeekAmount.update { if (value < 0 && it < 0 || pos.value + value > duration.value) 0 else it + value }
         _seekText.update { text }
         _isSeekingForwards.value = value > 0
-        seekBy(value, preciseSeek)
-        if (showSeekBar) showSeekBar()
+        seekBy(value, getPreciseSeek())
+        if (getShowSeekBar()) showSeekBar()
     }
 
     fun updateSeekAmount(amount: Int) {
@@ -930,20 +930,20 @@ class PlayerViewModel @JvmOverloads constructor(
 
     fun leftSeek() {
         if (pos.value > 0) {
-            _doubleTapSeekAmount.value -= doubleTapToSeekDuration
+            _doubleTapSeekAmount.value -= getDoubleTapToSeekDuration()
         }
         _isSeekingForwards.value = false
-        seekBy(-doubleTapToSeekDuration, preciseSeek)
-        if (showSeekBar) showSeekBar()
+        seekBy(-getDoubleTapToSeekDuration(), getPreciseSeek())
+        if (getShowSeekBar()) showSeekBar()
     }
 
     fun rightSeek() {
         if (pos.value < duration.value) {
-            _doubleTapSeekAmount.value += doubleTapToSeekDuration
+            _doubleTapSeekAmount.value += getDoubleTapToSeekDuration()
         }
         _isSeekingForwards.value = true
-        seekBy(doubleTapToSeekDuration, preciseSeek)
-        if (showSeekBar) showSeekBar()
+        seekBy(getDoubleTapToSeekDuration(), getPreciseSeek())
+        if (getShowSeekBar()) showSeekBar()
     }
 
     fun resetHosterState() {


### PR DESCRIPTION
Fixes #2327
Fixes #2286

**#2327 — Double tap to skip doesn't use custom skip duration**

The skip duration, smooth seek, and seek bar preferences were read once at ViewModel construction via `.get()` and stored as frozen `val` fields. Changes to these preferences had no effect until the player was recreated.

Changed from one-time `val` reads to `fun` calls that read the current preference value each time seek is triggered, so preference changes take effect immediately.

**#2286 — Crash when clicking Help in player custom button settings**

`PlayerSettingsMainScreen` is a `class` (not `object`) with a `private val items` field holding `Item` instances containing non-serializable types (`StringResource`, `ImageVector`, `VoyagerScreen`, composable lambdas). When the Help button opens a browser and the app goes to background, Android's `onStop` serializes the Navigator backstack, which includes this screen — causing `NotSerializableException: PlayerSettingsMainScreen$Item`.

Moved `items` from a class property to a `buildItems()` function, with the list computed locally in `Content()` via `remember { buildItems() }`. The screen now only holds `mainSettings: Boolean` as serializable state.

---

Self-review done. No visual changes. Both fixes are logic-only.