### PR TITLE
fix: Prevent keyboard from reopening after returning from search results

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/components/AppBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/AppBar.kt
@@ -1,13 +1,16 @@
 package eu.kanade.presentation.components
 
 import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -316,6 +319,12 @@ fun SearchToolbar(
                 focusManager.clearFocus()
                 keyboardController?.hide()
             }
+
+            // On Android < P clearing focus in touch mode makes the framework immediately
+            // pass focus back to the first focusable node. If that node is the text field,
+            // the keyboard reopens right after every dismissal and can never be closed
+            // (#2266), so give the bounced focus a harmless place to land instead.
+            Box(modifier = Modifier.size(1.dp).focusable())
 
             BasicTextField(
                 value = searchQuery,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/source/browse/BrowseAnimeSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/source/browse/BrowseAnimeSourceScreen.kt
@@ -32,7 +32,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalUriHandler
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -110,6 +112,8 @@ data class BrowseAnimeSourceScreen(
         val scope = rememberCoroutineScope()
         val haptic = LocalHapticFeedback.current
         val uriHandler = LocalUriHandler.current
+        val focusManager = LocalFocusManager.current
+        val keyboardController = LocalSoftwareKeyboardController.current
         val snackbarHostState = remember { SnackbarHostState() }
 
         val onHelpClick = { uriHandler.openUri(LocalAnimeSource.HELP_URL) }
@@ -229,7 +233,13 @@ data class BrowseAnimeSourceScreen(
                 onWebViewClick = onWebViewClick,
                 onHelpClick = { uriHandler.openUri(Constants.URL_HELP) },
                 onLocalAnimeSourceHelpClick = onHelpClick,
-                onAnimeClick = { navigator.push((AnimeScreen(it.id, true))) },
+                onAnimeClick = {
+                    // Release focus from the search field before leaving the screen, otherwise
+                    // the restored focus reopens the keyboard on return (#2266)
+                    focusManager.clearFocus()
+                    keyboardController?.hide()
+                    navigator.push(AnimeScreen(it.id, true))
+                },
                 onAnimeLongClick = { anime ->
                     scope.launchIO {
                         val duplicateAnime = screenModel.getDuplicateAnimelibAnime(anime)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/source/browse/BrowseMangaSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/source/browse/BrowseMangaSourceScreen.kt
@@ -32,7 +32,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalUriHandler
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -109,6 +111,8 @@ data class BrowseMangaSourceScreen(
         val scope = rememberCoroutineScope()
         val haptic = LocalHapticFeedback.current
         val uriHandler = LocalUriHandler.current
+        val focusManager = LocalFocusManager.current
+        val keyboardController = LocalSoftwareKeyboardController.current
         val snackbarHostState = remember { SnackbarHostState() }
 
         val onHelpClick = { uriHandler.openUri(LocalMangaSource.HELP_URL) }
@@ -228,7 +232,13 @@ data class BrowseMangaSourceScreen(
                 onWebViewClick = onWebViewClick,
                 onHelpClick = { uriHandler.openUri(Constants.URL_HELP) },
                 onLocalSourceHelpClick = onHelpClick,
-                onMangaClick = { navigator.push((MangaScreen(it.id, true))) },
+                onMangaClick = {
+                    // Release focus from the search field before leaving the screen, otherwise
+                    // the restored focus reopens the keyboard on return (#2266)
+                    focusManager.clearFocus()
+                    keyboardController?.hide()
+                    navigator.push(MangaScreen(it.id, true))
+                },
                 onMangaLongClick = { manga ->
                     scope.launchIO {
                         val duplicateManga = screenModel.getDuplicateLibraryManga(manga)


### PR DESCRIPTION
Closes #2266

### Problem

On Android 8.x, after searching in a source and opening an entry from the results, pressing back to return to the browse screen makes the keyboard pop up on its own — and pressing back again doesn't dismiss it; it keeps coming back (see the video in #2266).

### Root cause

On Android < 9, clearing focus while in touch mode makes the framework immediately reassign focus to the **first focusable node** in the hierarchy. Buttons aren't focusable in touch mode, so that node is the search `BasicTextField` in `SearchToolbar`. This has two effects:

1. Every keyboard dismissal (including the one done by `clearFocusOnSoftKeyboardHide`) bounces focus straight back into the text field, which immediately re-shows the keyboard — the endless loop from the report.
2. Because of that bounce, the field is still focused when navigating away to an entry. That focused state is restored when popping back (right as the screen transition finishes), which re-opens the keyboard.

I traced this with focus-event logging on an API 27 emulator: `clearFocus()` fires `focus=false` followed by `focus=true` ~1ms later, and on returning to the browse screen the restored focus arrives ~330ms after re-entry. Neither happens on modern Android, which is why the bug only affects older devices.

### Fix

- `SearchToolbar`: place a tiny (1dp) focusable node before the text field, so framework-initiated focus reassignment lands somewhere harmless instead of re-opening the keyboard. This fixes the "back button can't close the keyboard" loop for every screen using this toolbar.
- `BrowseAnimeSourceScreen` / `BrowseMangaSourceScreen`: release focus and hide the keyboard in the entry click handler before navigating, so there is no focused state to restore on return (same pattern `searchAndClearFocus` already uses when submitting a search).

### Testing

Verified on an Android 8.1 (API 27) emulator — the same Android version as the reporter's device — where the bug reproduced exactly as in the issue video before the fix:

- Search → open entry with keyboard up → back: keyboard no longer reopens (`dumpsys input_method` shows `mInputShown=false`, previously `true` even after multiple back presses).
- Focus field → back: keyboard closes with a single back press and stays closed.
- Regression-tested on Android 16 (API 36): search auto-opens the keyboard, typing/submitting filters results, the clear (X) button refocuses the field, and returning from an entry leaves the keyboard closed.

One note for anyone re-testing: `adb shell input keyevent 66` sends a *physical* Enter key, which switches the device out of touch mode and masks the bug — use touch interactions to reproduce.
