### PR TITLE
feat: Hide the blocking getTorrentInfo shim function

### DIFF
--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/torrentutils/TorrentUtils.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/torrentutils/TorrentUtils.kt
@@ -45,6 +45,11 @@ object TorrentUtils {
     // parameter is added by the Kotlin compiler). We add another overload of getTorrentInfo that is not a suspend
     // function so that extensions targetting other forks where getTorrentInfo was not a suspend function can still
     // work.
+    @Deprecated(
+        message = "This overload of getTorrentInfo exists only for binary compatibility with extensions targeting" +
+            " other forks where getTorrentInfo was not a suspend function",
+        level = DeprecationLevel.HIDDEN,
+    )
     @JvmName("getTorrentInfo")
     fun blockingShimForGetTorrentInfo(
         url: String,


### PR DESCRIPTION
A small followup to https://github.com/aniyomiorg/aniyomi/pull/2361. Hides the `blockingShimForGetTorrentInfo` function using `DeprecationLevel.HIDDEN`, which means that the function exists in the bytecode but is not otherwise accessible from Kotlin. This prevents anyone from calling this function in new code, while still maintaining binary compatibility with old extensions.

Tested with the Nyaa extension, confirmed that it still works (i.e. we aren't getting the missing method errors we were getting before the shim was introduced).