### PR TITLE
Local anime loading & thumbnail Extraction Improvement

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -416,6 +416,11 @@ object SettingsLibraryScreen : SearchableSettings {
                     ),
                     title = stringResource(AYMR.strings.pref_mark_duplicate_seen_episode_seen),
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = libraryPreferences.generateLocalThumbnails(),
+                    title = stringResource(AYMR.strings.pref_generate_local_thumbnails),
+                    subtitle = stringResource(AYMR.strings.pref_generate_local_thumbnails_summary),
+                ),
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreenModel.kt
@@ -72,6 +72,7 @@ import tachiyomi.core.common.preference.TriState
 import tachiyomi.core.common.preference.mapAsCheckboxState
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.launchNonCancellable
+import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.anime.interactor.GetAnimeCategories
@@ -295,7 +296,7 @@ class AnimeScreenModel(
         startTorrentServer(state.source)
 
         try {
-            withUIContext {
+            withIOContext {
                 when (state.anime.fetchType) {
                     FetchType.Episodes -> {
                         val update = updateAnimeFromRemote.awaitEpisodesUpdate(

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -227,6 +227,11 @@ class LibraryPreferences(
         Anime.EPISODE_SHOW_PREVIEWS,
     )
 
+    fun generateLocalThumbnails() = preferenceStore.getBoolean(
+        "generate_local_thumbnails",
+        true,
+    )
+
     fun showEpisodeSummaries() = preferenceStore.getLong(
         "default_episode_show_summaries",
         Anime.EPISODE_SHOW_SUMMARIES,

--- a/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
@@ -564,6 +564,8 @@
     <string name="pref_mark_duplicate_seen_episode_seen">Mark duplicate seen episode as seen</string>
     <string name="pref_mark_duplicate_seen_episode_seen_existing">After watching an episode</string>
     <string name="pref_mark_duplicate_seen_episode_seen_new">After fetching new episode</string>
+    <string name="pref_generate_local_thumbnails">Show thumbnails</string>
+    <string name="pref_generate_local_thumbnails_summary">Generate thumbnails from local anime episode files</string>
     <string name="pref_library_season">Season</string>
     <string name="pref_update_seasons_refresh">Update seasons with episodes on refresh</string>
     <string name="pref_update_seasons_update">Update seasons with episodes on library update</string>

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeFetchTypeManager.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeFetchTypeManager.kt
@@ -11,6 +11,7 @@ actual class LocalAnimeFetchTypeManager(
 ) {
     actual fun find(animeUrl: String): FetchType {
         val files = fileSystem.getFilesInAnimeDirectory(animeUrl)
+            .filterNot { it.name.orEmpty().startsWith('.') }
 
         return when {
             files.any { ArchiveAnime.isSupported(it) } -> FetchType.Episodes

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
@@ -342,7 +342,7 @@ actual class LocalAnimeSource(
                                 val previewUri = resultFile.uri.toString()
                                 ep.preview_url = previewUri
                                 val dbAnime = getAnimeByUrlAndSourceId.await(anime.url, ID)
-                                
+
                                 if (dbAnime != null) {
                                     val dbEpisode = getEpisodeByUrlAndAnimeId.await(ep.url, dbAnime.id)
                                     if (dbEpisode != null) {

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
@@ -40,6 +40,7 @@ import tachiyomi.domain.items.episode.interactor.GetEpisodeByUrlAndAnimeId
 import tachiyomi.domain.items.episode.interactor.UpdateEpisode
 import tachiyomi.domain.items.episode.model.EpisodeUpdate
 import tachiyomi.domain.items.episode.service.EpisodeRecognition
+import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.i18n.aniyomi.AYMR
 import tachiyomi.source.local.filter.anime.AnimeOrderBy
 import tachiyomi.source.local.image.anime.LocalAnimeBackgroundManager
@@ -70,6 +71,7 @@ actual class LocalAnimeSource(
     private val getEpisodeByUrlAndAnimeId: GetEpisodeByUrlAndAnimeId by injectLazy()
     private val updateEpisode: UpdateEpisode by injectLazy()
     private val animeRepository: AnimeRepository by injectLazy()
+    private val libraryPreferences: LibraryPreferences by injectLazy()
 
     private val thumbnailScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val thumbnailSemaphore = Semaphore(2)
@@ -302,7 +304,7 @@ actual class LocalAnimeSource(
 
                     if (thumbnailFile != null) {
                         this.preview_url = thumbnailFile.uri.toString()
-                    } else {
+                    } else if (libraryPreferences.generateLocalThumbnails().get()) {
                         val ep = this
                         thumbnailScope.launch {
                             thumbnailSemaphore.withPermit {
@@ -359,7 +361,7 @@ actual class LocalAnimeSource(
         }
         if (coverFile != null) {
             anime.thumbnail_url = coverFile.uri.toString()
-        } else {
+        } else if (libraryPreferences.generateLocalThumbnails().get()) {
             episodes.lastOrNull()?.let { episode ->
                 thumbnailScope.launch {
                     thumbnailSemaphore.withPermit {
@@ -404,7 +406,7 @@ actual class LocalAnimeSource(
 
         if (backgroundFile != null) {
             anime.background_url = backgroundFile.uri.toString()
-        } else {
+        } else if (libraryPreferences.generateLocalThumbnails().get()) {
             episodes.lastOrNull()?.let { episode ->
                 thumbnailScope.launch {
                     thumbnailSemaphore.withPermit {

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
@@ -13,9 +13,15 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.util.lang.compareToCaseInsensitiveNaturalOrder
 import eu.kanade.tachiyomi.util.storage.toFFmpegString
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import logcat.LogPriority
@@ -26,7 +32,13 @@ import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.core.metadata.tachiyomi.AnimeDetails
 import tachiyomi.core.metadata.tachiyomi.EpisodeDetails
+import tachiyomi.domain.entries.anime.interactor.GetAnimeByUrlAndSourceId
 import tachiyomi.domain.entries.anime.model.Anime
+import tachiyomi.domain.entries.anime.model.AnimeUpdate
+import tachiyomi.domain.entries.anime.repository.AnimeRepository
+import tachiyomi.domain.items.episode.interactor.GetEpisodeByUrlAndAnimeId
+import tachiyomi.domain.items.episode.interactor.UpdateEpisode
+import tachiyomi.domain.items.episode.model.EpisodeUpdate
 import tachiyomi.domain.items.episode.service.EpisodeRecognition
 import tachiyomi.i18n.aniyomi.AYMR
 import tachiyomi.source.local.filter.anime.AnimeOrderBy
@@ -39,6 +51,7 @@ import uy.kohesive.injekt.injectLazy
 import java.io.File
 import java.io.InputStream
 import java.text.SimpleDateFormat
+import java.time.Instant
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.math.abs
@@ -53,6 +66,13 @@ actual class LocalAnimeSource(
 ) : AnimeSource, UnmeteredSource {
 
     private val json: Json by injectLazy()
+    private val getAnimeByUrlAndSourceId: GetAnimeByUrlAndSourceId by injectLazy()
+    private val getEpisodeByUrlAndAnimeId: GetEpisodeByUrlAndAnimeId by injectLazy()
+    private val updateEpisode: UpdateEpisode by injectLazy()
+    private val animeRepository: AnimeRepository by injectLazy()
+
+    private val thumbnailScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val thumbnailSemaphore = Semaphore(2)
 
     @Suppress("PrivatePropertyName")
     private val PopularFilters = AnimeFilterList(AnimeOrderBy.Popular(context))
@@ -268,13 +288,44 @@ actual class LocalAnimeSource(
                     val thumbnailFile = thumbnailManager.find(anime.url, "${this.name}-$DEFAULT_THUMBNAIL_NAME")
                     if (thumbnailFile != null) {
                         this.preview_url = thumbnailFile.uri.toString()
-                    } else if (this.preview_url == null) {
-                        try {
-                            val tempFileSuffix = anime.title + this.name + DEFAULT_THUMBNAIL_NAME
-                            val updateThumbnail: (InputStream) -> Unit = { thumbnailManager.update(anime, this, it) }
-                            updateImageFromVideo(this, anime, tempFileSuffix, updateThumbnail)
-                        } catch (e: Exception) {
-                            logcat(LogPriority.ERROR) { "Couldn't extract thumbnail from video: $e" }
+                    } else {
+                        val ep = this
+                        thumbnailScope.launch {
+                            thumbnailSemaphore.withPermit {
+                                try {
+                                    val existingThumbnail = thumbnailManager.find(anime.url, "${ep.name}-$DEFAULT_THUMBNAIL_NAME")
+                                    val resultFile = if (existingThumbnail != null) {
+                                        existingThumbnail
+                                    } else {
+                                        val tempFileSuffix = anime.title + ep.name + DEFAULT_THUMBNAIL_NAME
+                                        var updatedFile: UniFile? = null
+                                        val updateThumbnail: (InputStream) -> Unit = { inputStream ->
+                                            updatedFile = thumbnailManager.update(anime, ep, inputStream)
+                                        }
+                                        updateImageFromVideo(ep, anime, tempFileSuffix, updateThumbnail)
+                                        updatedFile
+                                    }
+
+                                    if (resultFile != null) {
+                                        val previewUri = resultFile.uri.toString()
+                                        ep.preview_url = previewUri
+                                        val dbAnime = getAnimeByUrlAndSourceId.await(anime.url, ID)
+                                        if (dbAnime != null) {
+                                            val dbEpisode = getEpisodeByUrlAndAnimeId.await(ep.url, dbAnime.id)
+                                            if (dbEpisode != null) {
+                                                updateEpisode.await(
+                                                    EpisodeUpdate(
+                                                        id = dbEpisode.id,
+                                                        previewUrl = previewUri,
+                                                    ),
+                                                )
+                                            }
+                                        }
+                                    }
+                                } catch (e: Exception) {
+                                    logcat(LogPriority.ERROR) { "Couldn't extract thumbnail from video: $e" }
+                                }
+                            }
                         }
                     }
                 }
@@ -289,14 +340,39 @@ actual class LocalAnimeSource(
         if (existingCover != null) {
             anime.thumbnail_url = existingCover.uri.toString()
         } else {
-            try {
-                episodes.lastOrNull()?.let { episode ->
-                    val tempFileSuffix = anime.title + DEFAULT_COVER_NAME
-                    val updateCover: (InputStream) -> Unit = { coverManager.update(anime, it) }
-                    updateImageFromVideo(episode, anime, tempFileSuffix, updateCover)
+            episodes.lastOrNull()?.let { episode ->
+                thumbnailScope.launch {
+                    thumbnailSemaphore.withPermit {
+                        try {
+                            val currentCover = coverManager.find(anime.url)
+                            val coverFile = if (currentCover != null) {
+                                currentCover
+                            } else {
+                                val tempFileSuffix = anime.title + DEFAULT_COVER_NAME
+                                val updateCover: (InputStream) -> Unit = { coverManager.update(anime, it) }
+                                updateImageFromVideo(episode, anime, tempFileSuffix, updateCover)
+                                coverManager.find(anime.url)
+                            }
+
+                            if (coverFile != null) {
+                                val coverUri = coverFile.uri.toString()
+                                anime.thumbnail_url = coverUri
+                                val dbAnime = getAnimeByUrlAndSourceId.await(anime.url, ID)
+                                if (dbAnime != null) {
+                                    animeRepository.updateAnime(
+                                        AnimeUpdate(
+                                            id = dbAnime.id,
+                                            thumbnailUrl = coverUri,
+                                            coverLastModified = Instant.now().toEpochMilli(),
+                                        ),
+                                    )
+                                }
+                            }
+                        } catch (e: Exception) {
+                            logcat(LogPriority.ERROR) { "Couldn't extract cover from video: $e" }
+                        }
+                    }
                 }
-            } catch (e: Exception) {
-                logcat(LogPriority.ERROR) { "Couldn't extract cover from video: $e" }
             }
         }
 
@@ -305,14 +381,39 @@ actual class LocalAnimeSource(
         if (existingBackground != null) {
             anime.background_url = existingBackground.uri.toString()
         } else {
-            try {
-                episodes.lastOrNull()?.let { episode ->
-                    val tempFileSuffix = anime.title + DEFAULT_BACKGROUND_NAME
-                    val updateBackground: (InputStream) -> Unit = { backgroundManager.update(anime, it) }
-                    updateImageFromVideo(episode, anime, tempFileSuffix, updateBackground)
+            episodes.lastOrNull()?.let { episode ->
+                thumbnailScope.launch {
+                    thumbnailSemaphore.withPermit {
+                        try {
+                            val currentBg = backgroundManager.find(anime.url)
+                            val bgFile = if (currentBg != null) {
+                                currentBg
+                            } else {
+                                val tempFileSuffix = anime.title + DEFAULT_BACKGROUND_NAME
+                                val updateBackground: (InputStream) -> Unit = { backgroundManager.update(anime, it) }
+                                updateImageFromVideo(episode, anime, tempFileSuffix, updateBackground)
+                                backgroundManager.find(anime.url)
+                            }
+
+                            if (bgFile != null) {
+                                val bgUri = bgFile.uri.toString()
+                                anime.background_url = bgUri
+                                val dbAnime = getAnimeByUrlAndSourceId.await(anime.url, ID)
+                                if (dbAnime != null) {
+                                    animeRepository.updateAnime(
+                                        AnimeUpdate(
+                                            id = dbAnime.id,
+                                            backgroundUrl = bgUri,
+                                            backgroundLastModified = Instant.now().toEpochMilli(),
+                                        ),
+                                    )
+                                }
+                            }
+                        } catch (e: Exception) {
+                            logcat(LogPriority.ERROR) { "Couldn't extract background from video: $e" }
+                        }
+                    }
                 }
-            } catch (e: Exception) {
-                logcat(LogPriority.ERROR) { "Couldn't extract background from video: $e" }
             }
         }
 
@@ -343,25 +444,29 @@ actual class LocalAnimeSource(
             "tmp_",
             tempFileSuffix,
         )
-        val outFile = tempFile.path
+        try {
+            val outFile = tempFile.path
 
-        val episodeName = episode.url.split('/', limit = 2).last()
-        val animeDir = fileSystem.getAnimeDirectory(anime.url)!!
-        val episodeFile = animeDir.findFile(episodeName)!!
-        val episodeFilename = { episodeFile.toFFmpegString(context) }
+            val episodeName = episode.url.split('/', limit = 2).last()
+            val animeDir = fileSystem.getAnimeDirectory(anime.url)!!
+            val episodeFile = animeDir.findFile(episodeName)!!
+            val episodeFilename = { episodeFile.toFFmpegString(context) }
 
-        val ffProbe = com.arthenica.ffmpegkit.FFprobeKit.execute(
-            "-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 \"${episodeFilename()}\"",
-        )
-        val duration = ffProbe.allLogsAsString.trim().toFloat()
-        val second = duration.toInt() / 2
+            val ffProbe = com.arthenica.ffmpegkit.FFprobeKit.execute(
+                "-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 \"${episodeFilename()}\"",
+            )
+            val duration = ffProbe.allLogsAsString.trim().toFloat()
+            val second = duration.toInt() / 2
 
-        com.arthenica.ffmpegkit.FFmpegKit.execute(
-            "-ss $second -i \"${episodeFilename()}\" -frames:v 1 -update true \"$outFile\" -y",
-        )
+            com.arthenica.ffmpegkit.FFmpegKit.execute(
+                "-ss $second -i \"${episodeFilename()}\" -frames:v 1 -update true \"$outFile\" -y",
+            )
 
-        if (tempFile.length() > 0L) {
-            updateImage(tempFile.inputStream())
+            if (tempFile.length() > 0L) {
+                updateImage(tempFile.inputStream())
+            }
+        } finally {
+            tempFile.delete()
         }
     }
 

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
@@ -298,54 +298,12 @@ actual class LocalAnimeSource(
                         }
                     }
 
-                    // Generate the preview from the episode if not available
+                    // Generate the preview from the episode if available
                     val thumbnailName = "${this.name}-$DEFAULT_THUMBNAIL_NAME".substringBeforeLast('.').lowercase()
                     val thumbnailFile = thumbnailFilesMap[thumbnailName]
 
                     if (thumbnailFile != null) {
                         this.preview_url = thumbnailFile.uri.toString()
-                    } else if (libraryPreferences.generateLocalThumbnails().get()) {
-                        val ep = this
-                        thumbnailScope.launch {
-                            thumbnailSemaphore.withPermit {
-                                try {
-                                    val existingThumbnail = thumbnailManager.find(
-                                        anime.url,
-                                        "${ep.name}-$DEFAULT_THUMBNAIL_NAME",
-                                    )
-                                    val resultFile = if (existingThumbnail != null) {
-                                        existingThumbnail
-                                    } else {
-                                        val tempFileSuffix = anime.title + ep.name + DEFAULT_THUMBNAIL_NAME
-                                        var updatedFile: UniFile? = null
-                                        val updateThumbnail: (InputStream) -> Unit = { inputStream ->
-                                            updatedFile = thumbnailManager.update(anime, ep, inputStream)
-                                        }
-                                        updateImageFromVideo(ep, anime, tempFileSuffix, updateThumbnail)
-                                        updatedFile
-                                    }
-
-                                    if (resultFile != null) {
-                                        val previewUri = resultFile.uri.toString()
-                                        ep.preview_url = previewUri
-                                        val dbAnime = getAnimeByUrlAndSourceId.await(anime.url, ID)
-                                        if (dbAnime != null) {
-                                            val dbEpisode = getEpisodeByUrlAndAnimeId.await(ep.url, dbAnime.id)
-                                            if (dbEpisode != null) {
-                                                updateEpisode.await(
-                                                    EpisodeUpdate(
-                                                        id = dbEpisode.id,
-                                                        previewUrl = previewUri,
-                                                    ),
-                                                )
-                                            }
-                                        }
-                                    }
-                                } catch (e: Exception) {
-                                    logcat(LogPriority.ERROR) { "Couldn't extract thumbnail from video: $e" }
-                                }
-                            }
-                        }
                     }
                 }
             }
@@ -353,6 +311,57 @@ actual class LocalAnimeSource(
                 val e = e2.episode_number.compareTo(e1.episode_number)
                 if (e == 0) e2.name.compareToCaseInsensitiveNaturalOrder(e1.name) else e
             }
+
+        val missingThumbnails = episodes.filter { it.preview_url.isNullOrBlank() }
+        if (missingThumbnails.isNotEmpty() && libraryPreferences.generateLocalThumbnails().get()) {
+            val dbAnime = getAnimeByUrlAndSourceId.await(anime.url, ID)
+            val sortDescending = dbAnime?.sortDescending() ?: true
+            val orderedMissingThumbnails = if (sortDescending) missingThumbnails else missingThumbnails.reversed()
+
+            orderedMissingThumbnails.forEach { ep ->
+                thumbnailScope.launch {
+                    thumbnailSemaphore.withPermit {
+                        try {
+                            val existingThumbnail = thumbnailManager.find(
+                                anime.url,
+                                "${ep.name}-$DEFAULT_THUMBNAIL_NAME",
+                            )
+                            val resultFile = if (existingThumbnail != null) {
+                                existingThumbnail
+                            } else {
+                                val tempFileSuffix = anime.title + ep.name + DEFAULT_THUMBNAIL_NAME
+                                var updatedFile: UniFile? = null
+                                val updateThumbnail: (InputStream) -> Unit = { inputStream ->
+                                    updatedFile = thumbnailManager.update(anime, ep, inputStream)
+                                }
+                                updateImageFromVideo(ep, anime, tempFileSuffix, updateThumbnail)
+                                updatedFile
+                            }
+
+                            if (resultFile != null) {
+                                val previewUri = resultFile.uri.toString()
+                                ep.preview_url = previewUri
+                                val dbAnime = getAnimeByUrlAndSourceId.await(anime.url, ID)
+                                
+                                if (dbAnime != null) {
+                                    val dbEpisode = getEpisodeByUrlAndAnimeId.await(ep.url, dbAnime.id)
+                                    if (dbEpisode != null) {
+                                        updateEpisode.await(
+                                            EpisodeUpdate(
+                                                id = dbEpisode.id,
+                                                previewUrl = previewUri,
+                                            ),
+                                        )
+                                    }
+                                }
+                            }
+                        } catch (e: Exception) {
+                            logcat(LogPriority.ERROR) { "Couldn't extract thumbnail from video: $e" }
+                        }
+                    }
+                }
+            }
+        }
 
         // Generate the cover from the first episode found if not available
         val coverFile = filesInAnimeDir.firstOrNull {

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
@@ -288,7 +288,7 @@ actual class LocalAnimeSource(
         val existingCover = coverManager.find(anime.url)
         if (existingCover != null) {
             anime.thumbnail_url = existingCover.uri.toString()
-        } else if (anime.thumbnail_url == null) {
+        } else {
             try {
                 episodes.lastOrNull()?.let { episode ->
                     val tempFileSuffix = anime.title + DEFAULT_COVER_NAME
@@ -304,7 +304,7 @@ actual class LocalAnimeSource(
         val existingBackground = backgroundManager.find(anime.url)
         if (existingBackground != null) {
             anime.background_url = existingBackground.uri.toString()
-        } else if (anime.background_url == null) {
+        } else {
             try {
                 episodes.lastOrNull()?.let { episode ->
                     val tempFileSuffix = anime.title + DEFAULT_BACKGROUND_NAME

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
@@ -198,15 +198,19 @@ actual class LocalAnimeSource(
 
     // Anime details related
     private suspend fun getOldAnimeDetails(anime: SAnime): SAnime = withIOContext {
-        coverManager.find(anime.url)?.let {
+        val animeDirFiles = fileSystem.getFilesInAnimeDirectory(anime.url)
+
+        animeDirFiles.firstOrNull {
+            it.isFile && it.nameWithoutExtension.equals("cover", ignoreCase = true)
+        }?.let {
             anime.thumbnail_url = it.uri.toString()
         }
 
-        backgroundManager.find(anime.url)?.let {
+        animeDirFiles.firstOrNull {
+            it.isFile && it.nameWithoutExtension.equals("background", ignoreCase = true)
+        }?.let {
             anime.background_url = it.uri.toString()
         }
-
-        val animeDirFiles = fileSystem.getFilesInAnimeDirectory(anime.url)
 
         animeDirFiles
             .firstOrNull { it.extension == "json" && it.nameWithoutExtension == "details" }
@@ -250,14 +254,22 @@ actual class LocalAnimeSource(
 
     // Episodes
     private suspend fun getOldEpisodeList(anime: SAnime): List<SEpisode> = withIOContext {
-        val episodesData = fileSystem.getFilesInAnimeDirectory(anime.url)
+        val animeDir = fileSystem.getAnimeDirectory(anime.url)
+        val filesInAnimeDir = animeDir?.listFiles().orEmpty().toList()
+        val thumbnailsDirFiles = animeDir?.findFile(THUMBNAILS_DIR)?.listFiles().orEmpty().toList()
+
+        val episodesData = filesInAnimeDir
             .firstOrNull {
                 it.extension == "json" && it.nameWithoutExtension == "episodes"
             }?.let { file ->
                 json.decodeFromStream<List<EpisodeDetails>>(file.openInputStream())
             }
 
-        val episodes = fileSystem.getFilesInAnimeDirectory(anime.url)
+        val thumbnailFilesMap = (thumbnailsDirFiles + filesInAnimeDir)
+            .filter { it.isFile }
+            .associateBy { it.nameWithoutExtension.orEmpty().lowercase() }
+
+        val episodes = filesInAnimeDir
             // Only keep supported formats
             .filterNot { it.name.orEmpty().startsWith('.') }
             .filter { ArchiveAnime.isSupported(it) }
@@ -285,7 +297,9 @@ actual class LocalAnimeSource(
                     }
 
                     // Generate the preview from the episode if not available
-                    val thumbnailFile = thumbnailManager.find(anime.url, "${this.name}-$DEFAULT_THUMBNAIL_NAME")
+                    val thumbnailName = "${this.name}-$DEFAULT_THUMBNAIL_NAME".substringBeforeLast('.').lowercase()
+                    val thumbnailFile = thumbnailFilesMap[thumbnailName]
+
                     if (thumbnailFile != null) {
                         this.preview_url = thumbnailFile.uri.toString()
                     } else {
@@ -339,9 +353,12 @@ actual class LocalAnimeSource(
             }
 
         // Generate the cover from the first episode found if not available
-        val existingCover = coverManager.find(anime.url)
-        if (existingCover != null) {
-            anime.thumbnail_url = existingCover.uri.toString()
+        val coverFile = filesInAnimeDir.firstOrNull {
+            it.isFile &&
+                it.nameWithoutExtension.equals("cover", ignoreCase = true)
+        }
+        if (coverFile != null) {
+            anime.thumbnail_url = coverFile.uri.toString()
         } else {
             episodes.lastOrNull()?.let { episode ->
                 thumbnailScope.launch {
@@ -380,9 +397,13 @@ actual class LocalAnimeSource(
         }
 
         // Generate the background from the first episode found if not available
-        val existingBackground = backgroundManager.find(anime.url)
-        if (existingBackground != null) {
-            anime.background_url = existingBackground.uri.toString()
+        val backgroundFile = filesInAnimeDir.firstOrNull {
+            it.isFile &&
+                it.nameWithoutExtension.equals("background", ignoreCase = true)
+        }
+
+        if (backgroundFile != null) {
+            anime.background_url = backgroundFile.uri.toString()
         } else {
             episodes.lastOrNull()?.let { episode ->
                 thumbnailScope.launch {

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
@@ -265,7 +265,10 @@ actual class LocalAnimeSource(
                     }
 
                     // Generate the preview from the episode if not available
-                    if (this.preview_url == null) {
+                    val thumbnailFile = thumbnailManager.find(anime.url, "${this.name}-$DEFAULT_THUMBNAIL_NAME")
+                    if (thumbnailFile != null) {
+                        this.preview_url = thumbnailFile.uri.toString()
+                    } else if (this.preview_url == null) {
                         try {
                             val tempFileSuffix = anime.title + this.name + DEFAULT_THUMBNAIL_NAME
                             val updateThumbnail: (InputStream) -> Unit = { thumbnailManager.update(anime, this, it) }
@@ -282,7 +285,10 @@ actual class LocalAnimeSource(
             }
 
         // Generate the cover from the first episode found if not available
-        if (anime.thumbnail_url == null || coverManager.find(anime.url) == null) {
+        val existingCover = coverManager.find(anime.url)
+        if (existingCover != null) {
+            anime.thumbnail_url = existingCover.uri.toString()
+        } else if (anime.thumbnail_url == null) {
             try {
                 episodes.lastOrNull()?.let { episode ->
                     val tempFileSuffix = anime.title + DEFAULT_COVER_NAME
@@ -295,7 +301,10 @@ actual class LocalAnimeSource(
         }
 
         // Generate the background from the first episode found if not available
-        if (anime.background_url == null || backgroundManager.find(anime.url) == null) {
+        val existingBackground = backgroundManager.find(anime.url)
+        if (existingBackground != null) {
+            anime.background_url = existingBackground.uri.toString()
+        } else if (anime.background_url == null) {
             try {
                 episodes.lastOrNull()?.let { episode ->
                     val tempFileSuffix = anime.title + DEFAULT_BACKGROUND_NAME
@@ -360,9 +369,11 @@ actual class LocalAnimeSource(
         const val ID = 0L
         const val HELP_URL = "https://aniyomi.org/help/guides/local-anime/"
 
-        private const val DEFAULT_COVER_NAME = "cover.jpg"
-        private const val DEFAULT_BACKGROUND_NAME = "background.jpg"
-        private const val DEFAULT_THUMBNAIL_NAME = "thumbnail.jpg"
+        internal const val DEFAULT_COVER_NAME = "cover.jpg"
+        internal const val DEFAULT_BACKGROUND_NAME = "background.jpg"
+        internal const val DEFAULT_THUMBNAIL_NAME = "thumbnail.jpg"
+        internal const val THUMBNAILS_DIR = ".thumbnails"
+
         private val LATEST_THRESHOLD = TimeUnit.MILLISECONDS.convert(7, TimeUnit.DAYS)
     }
 }

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
@@ -72,7 +72,7 @@ actual class LocalAnimeSource(
     private val animeRepository: AnimeRepository by injectLazy()
 
     private val thumbnailScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val thumbnailSemaphore = Semaphore(1)
+    private val thumbnailSemaphore = Semaphore(2)
 
     @Suppress("PrivatePropertyName")
     private val PopularFilters = AnimeFilterList(AnimeOrderBy.Popular(context))
@@ -345,17 +345,17 @@ actual class LocalAnimeSource(
                     thumbnailSemaphore.withPermit {
                         try {
                             val currentCover = coverManager.find(anime.url)
-                            val coverFile = if (currentCover != null) {
+                            val resultCoverFile = if (currentCover != null) {
                                 currentCover
                             } else {
                                 val tempFileSuffix = anime.title + DEFAULT_COVER_NAME
                                 val updateCover: (InputStream) -> Unit = { coverManager.update(anime, it) }
-                                updateImageFromVideo(episode, anime, tempFileSuffix, updateCover)
+                                updateImageFromVideo(episode, anime, tempFileSuffix, updateCover, 600)
                                 coverManager.find(anime.url)
                             }
 
-                            if (coverFile != null) {
-                                val coverUri = coverFile.uri.toString()
+                            if (resultCoverFile != null) {
+                                val coverUri = resultCoverFile.uri.toString()
                                 anime.thumbnail_url = coverUri
                                 val dbAnime = getAnimeByUrlAndSourceId.await(anime.url, ID)
                                 if (dbAnime != null) {
@@ -386,17 +386,17 @@ actual class LocalAnimeSource(
                     thumbnailSemaphore.withPermit {
                         try {
                             val currentBg = backgroundManager.find(anime.url)
-                            val bgFile = if (currentBg != null) {
+                            val resultBgFile = if (currentBg != null) {
                                 currentBg
                             } else {
                                 val tempFileSuffix = anime.title + DEFAULT_BACKGROUND_NAME
                                 val updateBackground: (InputStream) -> Unit = { backgroundManager.update(anime, it) }
-                                updateImageFromVideo(episode, anime, tempFileSuffix, updateBackground)
+                                updateImageFromVideo(episode, anime, tempFileSuffix, updateBackground, 960)
                                 backgroundManager.find(anime.url)
                             }
 
-                            if (bgFile != null) {
-                                val bgUri = bgFile.uri.toString()
+                            if (resultBgFile != null) {
+                                val bgUri = resultBgFile.uri.toString()
                                 anime.background_url = bgUri
                                 val dbAnime = getAnimeByUrlAndSourceId.await(anime.url, ID)
                                 if (dbAnime != null) {
@@ -439,6 +439,7 @@ actual class LocalAnimeSource(
         anime: SAnime,
         tempFileSuffix: String,
         updateImage: (InputStream) -> Unit,
+        targetWidth: Int = 720,
     ) {
         val tempFile = File.createTempFile(
             "tmp_",
@@ -455,11 +456,11 @@ actual class LocalAnimeSource(
             val ffProbe = com.arthenica.ffmpegkit.FFprobeKit.execute(
                 "-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 \"${episodeFilename()}\"",
             )
-            val duration = ffProbe.allLogsAsString.trim().toFloat()
-            val second = duration.toInt() / 2
+            val duration = ffProbe.allLogsAsString.trim().toFloatOrNull() ?: 120f
+            val second = (duration.toInt() / 2).coerceAtLeast(1)
 
             com.arthenica.ffmpegkit.FFmpegKit.execute(
-                "-ss $second -i \"${episodeFilename()}\" -frames:v 1 -update true \"$outFile\" -y",
+                "-ss $second -noaccurate_seek -i \"${episodeFilename()}\" -vf \"scale='min($targetWidth,iw)':-2\" -q:v 3 -frames:v 1 -update true \"$outFile\" -y",
             )
 
             if (tempFile.length() > 0L) {

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
@@ -72,7 +72,7 @@ actual class LocalAnimeSource(
     private val animeRepository: AnimeRepository by injectLazy()
 
     private val thumbnailScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val thumbnailSemaphore = Semaphore(2)
+    private val thumbnailSemaphore = Semaphore(1)
 
     @Suppress("PrivatePropertyName")
     private val PopularFilters = AnimeFilterList(AnimeOrderBy.Popular(context))

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/entries/anime/LocalAnimeSource.kt
@@ -293,7 +293,10 @@ actual class LocalAnimeSource(
                         thumbnailScope.launch {
                             thumbnailSemaphore.withPermit {
                                 try {
-                                    val existingThumbnail = thumbnailManager.find(anime.url, "${ep.name}-$DEFAULT_THUMBNAIL_NAME")
+                                    val existingThumbnail = thumbnailManager.find(
+                                        anime.url,
+                                        "${ep.name}-$DEFAULT_THUMBNAIL_NAME",
+                                    )
                                     val resultFile = if (existingThumbnail != null) {
                                         existingThumbnail
                                     } else {

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalAnimeBackgroundManager.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalAnimeBackgroundManager.kt
@@ -6,10 +6,9 @@ import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import tachiyomi.core.common.storage.nameWithoutExtension
 import tachiyomi.core.common.util.system.ImageUtil
+import tachiyomi.source.local.entries.anime.LocalAnimeSource
 import tachiyomi.source.local.io.anime.LocalAnimeSourceFileSystem
 import java.io.InputStream
-
-private const val DEFAULT_BACKGROUND_NAME = "background.jpg"
 
 actual class LocalAnimeBackgroundManager(
     private val context: Context,
@@ -31,15 +30,13 @@ actual class LocalAnimeBackgroundManager(
             return null
         }
 
-        val targetFile = find(anime.url) ?: directory.createFile(DEFAULT_BACKGROUND_NAME)!!
+        val targetFile = find(anime.url) ?: directory.createFile(LocalAnimeSource.DEFAULT_BACKGROUND_NAME)!!
 
         inputStream.use { input ->
             targetFile.openOutputStream().use { output ->
                 input.copyTo(output)
             }
         }
-
-        DiskUtil.createNoMediaFile(directory, context)
 
         anime.background_url = targetFile.uri.toString()
         return targetFile

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalAnimeBackgroundManager.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalAnimeBackgroundManager.kt
@@ -3,7 +3,6 @@ package tachiyomi.source.local.image.anime
 import android.content.Context
 import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.animesource.model.SAnime
-import eu.kanade.tachiyomi.util.storage.DiskUtil
 import tachiyomi.core.common.storage.nameWithoutExtension
 import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.source.local.entries.anime.LocalAnimeSource

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalAnimeCoverManager.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalAnimeCoverManager.kt
@@ -6,10 +6,9 @@ import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import tachiyomi.core.common.storage.nameWithoutExtension
 import tachiyomi.core.common.util.system.ImageUtil
+import tachiyomi.source.local.entries.anime.LocalAnimeSource
 import tachiyomi.source.local.io.anime.LocalAnimeSourceFileSystem
 import java.io.InputStream
-
-private const val DEFAULT_COVER_NAME = "cover.jpg"
 
 actual class LocalAnimeCoverManager(
     private val context: Context,
@@ -31,15 +30,13 @@ actual class LocalAnimeCoverManager(
             return null
         }
 
-        val targetFile = find(anime.url) ?: directory.createFile(DEFAULT_COVER_NAME)!!
+        val targetFile = find(anime.url) ?: directory.createFile(LocalAnimeSource.DEFAULT_COVER_NAME)!!
 
         inputStream.use { input ->
             targetFile.openOutputStream().use { output ->
                 input.copyTo(output)
             }
         }
-
-        DiskUtil.createNoMediaFile(directory, context)
 
         anime.thumbnail_url = targetFile.uri.toString()
         return targetFile

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalAnimeCoverManager.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalAnimeCoverManager.kt
@@ -3,7 +3,6 @@ package tachiyomi.source.local.image.anime
 import android.content.Context
 import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.animesource.model.SAnime
-import eu.kanade.tachiyomi.util.storage.DiskUtil
 import tachiyomi.core.common.storage.nameWithoutExtension
 import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.source.local.entries.anime.LocalAnimeSource

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalEpisodeThumbnailManager.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalEpisodeThumbnailManager.kt
@@ -7,10 +7,9 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import tachiyomi.core.common.storage.nameWithoutExtension
 import tachiyomi.core.common.util.system.ImageUtil
+import tachiyomi.source.local.entries.anime.LocalAnimeSource
 import tachiyomi.source.local.io.anime.LocalAnimeSourceFileSystem
 import java.io.InputStream
-
-private const val DEFAULT_THUMBNAIL_NAME = "thumbnail.jpg"
 
 actual class LocalEpisodeThumbnailManager(
     private val context: Context,
@@ -18,9 +17,21 @@ actual class LocalEpisodeThumbnailManager(
 ) {
 
     actual fun find(animeUrl: String, fileName: String): UniFile? {
-        return fileSystem.getFilesInAnimeDirectory(animeUrl)
-            // Get all file whose names contain the episode name and the word 'thumbnail'
-            .filter { it.isFile && it.nameWithoutExtension.equals(fileName, ignoreCase = true) }
+        val animeDir = fileSystem.getAnimeDirectory(animeUrl)
+        val thumbnailsDir = animeDir?.findFile(LocalAnimeSource.THUMBNAILS_DIR)
+        val files = thumbnailsDir?.listFiles().orEmpty().toList() +
+            fileSystem.getFilesInAnimeDirectory(animeUrl)
+
+        val nameToMatch = fileName.substringBeforeLast('.')
+
+        return files
+            // Get all file whose names match the episode thumbnail name
+            .filter {
+                it.isFile && (
+                    it.name.equals(fileName, ignoreCase = true) ||
+                        it.nameWithoutExtension.equals(nameToMatch, ignoreCase = true)
+                    )
+            }
             // Get the first actual image
             .firstOrNull { ImageUtil.isImage(it.name) { it.openInputStream() } }
     }
@@ -32,8 +43,9 @@ actual class LocalEpisodeThumbnailManager(
             return null
         }
 
-        val fileName = "${episode.name}-$DEFAULT_THUMBNAIL_NAME"
-        val targetFile = find(anime.url, fileName) ?: directory.createFile(fileName)!!
+        val thumbnailsDir = directory.createDirectory(LocalAnimeSource.THUMBNAILS_DIR)!!
+        val fileName = "${episode.name}-${LocalAnimeSource.DEFAULT_THUMBNAIL_NAME}"
+        val targetFile = find(anime.url, fileName) ?: thumbnailsDir.createFile(fileName)!!
 
         inputStream.use { input ->
             targetFile.openOutputStream().use { output ->
@@ -41,7 +53,7 @@ actual class LocalEpisodeThumbnailManager(
             }
         }
 
-        DiskUtil.createNoMediaFile(directory, context)
+        DiskUtil.createNoMediaFile(thumbnailsDir, context)
 
         episode.preview_url = targetFile.uri.toString()
         return targetFile

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalEpisodeThumbnailManager.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/image/anime/LocalEpisodeThumbnailManager.kt
@@ -27,10 +27,11 @@ actual class LocalEpisodeThumbnailManager(
         return files
             // Get all file whose names match the episode thumbnail name
             .filter {
-                it.isFile && (
-                    it.name.equals(fileName, ignoreCase = true) ||
-                        it.nameWithoutExtension.equals(nameToMatch, ignoreCase = true)
-                    )
+                it.isFile &&
+                    (
+                        it.name.equals(fileName, ignoreCase = true) ||
+                            it.nameWithoutExtension.equals(nameToMatch, ignoreCase = true)
+                        )
             }
             // Get the first actual image
             .firstOrNull { ImageUtil.isImage(it.name) { it.openInputStream() } }


### PR DESCRIPTION
This pr improves local loading and thumbnail generation.

## Changes

### Episode list loading

0. Pre fetch directory contents in memory once instead of per episode SAF calls

0. Offloaded `fetchAllFromSource` to `Dispatchers.IO` so the UI thread doesn't lag for long  while background scans run.


### Thumbnail Generation

0. Instead of cluttering anime dir with thumbnails, now putting thumbnails in .thumbnail subdir. this keeps root dir clean.

0. Previously ui was stuck at loading untill all episodes' thumbnails were fetched . Instead of that now at first episodes are loaded then asynchronously thumbnails are extracted and shown one by one after each episode  generation finishes. 

0. Using `-noaccurate_seek` and 720p resolution setting with ffmpeg for thumbnails speeding up with minimmal quality compromises. 

0.  Added option in settings to disable thumbnail generation globally. `settings->library->episode settings->Show thumbnails`

## Behaviour Now

<img height="500" alt="IMG_20260816_144852" src="https://github.com/user-attachments/assets/46f4e056-87f3-4c5f-ae63-e7d7555521d2" />


https://github.com/user-attachments/assets/133a960c-ea4f-453a-a9e6-9981ddf056cb



