### PR TITLE
Add `memo` to `Hoster` and `Video`

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/entries/anime/EpisodeOptionsDialogScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/anime/EpisodeOptionsDialogScreen.kt
@@ -380,13 +380,11 @@ class EpisodeOptionsDialogScreenModel(
                     hosterName = h.hosterName,
                     hosterUrl = h.hosterUrl,
                     videoList = (hosterStateList[index] as HosterState.Ready).videoList,
+                    internalData = h.internalData,
+                    memo = h.memo,
                 )
             } else {
-                Hoster(
-                    hosterName = h.hosterName,
-                    hosterUrl = h.hosterUrl,
-                    videoList = h.videoList,
-                )
+                h
             }
         }
     }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/animesource/model/Hoster.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/animesource/model/Hoster.kt
@@ -3,8 +3,9 @@ package eu.kanade.tachiyomi.animesource.model
 import eu.kanade.tachiyomi.animesource.model.SerializableVideo.Companion.serialize
 import eu.kanade.tachiyomi.animesource.model.SerializableVideo.Companion.toVideoList
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import mihon.core.common.extensions.EMPTY
 
 open class Hoster(
     val hosterUrl: String = "",
@@ -12,6 +13,7 @@ open class Hoster(
     val videoList: List<Video>? = null,
     val internalData: String = "",
     val lazy: Boolean = false,
+    val memo: JsonObject = JsonObject.EMPTY,
 ) {
     @Transient
     @Volatile
@@ -24,14 +26,31 @@ open class Hoster(
         ERROR,
     }
 
+    // Ext lib 16 constructor
+    constructor(
+        hosterUrl: String = "",
+        hosterName: String = "",
+        videoList: List<Video>? = null,
+        internalData: String = "",
+        lazy: Boolean = false,
+    ) : this(
+        hosterUrl = hosterUrl,
+        hosterName = hosterName,
+        videoList = videoList,
+        internalData = internalData,
+        lazy = lazy,
+        memo = JsonObject.EMPTY,
+    )
+
     fun copy(
         hosterUrl: String = this.hosterUrl,
         hosterName: String = this.hosterName,
         videoList: List<Video>? = this.videoList,
         internalData: String = this.internalData,
         lazy: Boolean = this.lazy,
+        memo: JsonObject = this.memo,
     ): Hoster {
-        return Hoster(hosterUrl, hosterName, videoList, internalData, lazy)
+        return Hoster(hosterUrl, hosterName, videoList, internalData, lazy, memo)
     }
 
     companion object {
@@ -43,6 +62,7 @@ open class Hoster(
                     hosterUrl = "",
                     hosterName = NO_HOSTER_LIST,
                     videoList = this,
+                    memo = JsonObject.EMPTY,
                 ),
             )
         }
@@ -54,8 +74,9 @@ data class SerializableHoster(
     val hosterUrl: String = "",
     val hosterName: String = "",
     val videoList: String? = null,
-    val internalData: String = "",
+    val internalData: String,
     val lazy: Boolean = false,
+    val memo: JsonObject = JsonObject.EMPTY,
 ) {
     companion object {
         fun List<Hoster>.serialize(): String =
@@ -67,6 +88,7 @@ data class SerializableHoster(
                         host.videoList?.serialize(),
                         host.internalData,
                         host.lazy,
+                        host.memo,
                     )
                 },
             )
@@ -80,6 +102,7 @@ data class SerializableHoster(
                         sHost.videoList?.toVideoList(),
                         sHost.internalData,
                         sHost.lazy,
+                        sHost.memo,
                     )
                 }
     }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/animesource/model/Video.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/animesource/model/Video.kt
@@ -2,8 +2,9 @@ package eu.kanade.tachiyomi.animesource.model
 
 import android.net.Uri
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import mihon.core.common.extensions.EMPTY
 import okhttp3.Headers
 
 @Serializable
@@ -41,8 +42,8 @@ data class Video(
     val ffmpegVideoArgs: List<Pair<String, String>> = emptyList(),
     val internalData: String = "",
     val initialized: Boolean = false,
+    val memo: JsonObject = JsonObject.EMPTY,
 ) {
-
     // TODO(1.6): Remove after ext lib bump
     @Deprecated("Use videoTitle instead", ReplaceWith("videoTitle"))
     val quality: String
@@ -82,6 +83,63 @@ data class Video(
         uri: Uri? = null,
         headers: Headers? = null,
     ) : this(url, quality, videoUrl, headers)
+
+    // Ext lib 16 constructor
+    @Deprecated("Used only for compatibility with ext lib 16, do not use", level = DeprecationLevel.HIDDEN)
+    constructor(
+        videoUrl: String = "",
+        videoTitle: String = "",
+        resolution: Int? = null,
+        bitrate: Int? = null,
+        headers: Headers? = null,
+        preferred: Boolean = false,
+        subtitleTracks: List<Track> = emptyList(),
+        audioTracks: List<Track> = emptyList(),
+        timestamps: List<TimeStamp> = emptyList(),
+        mpvArgs: List<Pair<String, String>> = emptyList(),
+        ffmpegStreamArgs: List<Pair<String, String>> = emptyList(),
+        ffmpegVideoArgs: List<Pair<String, String>> = emptyList(),
+        internalData: String = "",
+        initialized: Boolean = false,
+    ) : this(
+        videoUrl, videoTitle, resolution, bitrate, headers, preferred, subtitleTracks, audioTracks, timestamps, mpvArgs,
+        ffmpegStreamArgs, ffmpegVideoArgs, internalData, initialized, JsonObject.EMPTY,
+    )
+
+    // Ext lib 16 copy video
+    @Deprecated("Used only for compatibility with ext lib 16, do not use", level = DeprecationLevel.HIDDEN)
+    fun copy(
+        videoUrl: String = this.videoUrl,
+        videoTitle: String = this.videoTitle,
+        resolution: Int? = this.resolution,
+        bitrate: Int? = this.bitrate,
+        headers: Headers? = this.headers,
+        preferred: Boolean = this.preferred,
+        subtitleTracks: List<Track> = this.subtitleTracks,
+        audioTracks: List<Track> = this.audioTracks,
+        timestamps: List<TimeStamp> = this.timestamps,
+        mpvArgs: List<Pair<String, String>> = this.mpvArgs,
+        ffmpegStreamArgs: List<Pair<String, String>> = this.ffmpegStreamArgs,
+        ffmpegVideoArgs: List<Pair<String, String>> = this.ffmpegVideoArgs,
+        internalData: String = this.internalData,
+        initialized: Boolean = this.initialized,
+    ): Video = Video(
+        videoUrl = videoUrl,
+        videoTitle = videoTitle,
+        resolution = resolution,
+        bitrate = bitrate,
+        headers = headers,
+        preferred = preferred,
+        subtitleTracks = subtitleTracks,
+        audioTracks = audioTracks,
+        timestamps = timestamps,
+        mpvArgs = mpvArgs,
+        ffmpegStreamArgs = ffmpegStreamArgs,
+        ffmpegVideoArgs = ffmpegVideoArgs,
+        internalData = internalData,
+        initialized = initialized,
+        memo = JsonObject.EMPTY,
+    )
 
     @Transient
     @Volatile
@@ -148,6 +206,7 @@ data class SerializableVideo(
     val ffmpegVideoArgs: List<Pair<String, String>> = emptyList(),
     val internalData: String = "",
     val initialized: Boolean = false,
+    val memo: JsonObject = JsonObject.EMPTY,
 ) {
 
     companion object {
@@ -169,6 +228,7 @@ data class SerializableVideo(
                         vid.ffmpegVideoArgs,
                         vid.internalData,
                         vid.initialized,
+                        vid.memo,
                     )
                 },
             )
@@ -193,6 +253,7 @@ data class SerializableVideo(
                         sVid.ffmpegVideoArgs,
                         sVid.internalData,
                         sVid.initialized,
+                        sVid.memo,
                     )
                 }
     }


### PR DESCRIPTION
Trying to remove internalData from the primary constructor seemed to cause a bunch of issues with default parameter which i couldn't figure out how to solve, so for now they have both. In the extensions-lib it is marked as deprecated.