### PR TITLE
support .pb new manga extension type

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -384,7 +384,7 @@ class DomainModule : InjektModule {
         addFactory { TrustAnimeExtension(get(), get()) }
         addFactory { TrustMangaExtension(get(), get()) }
 
-        addFactory { ExtensionRepoService(get(), get()) }
+        addFactory { ExtensionRepoService(get(), get(), get()) }
 
         addSingletonFactory { AnimeExtensionStoreService(get(), get(), get()) }
         addSingletonFactory<AnimeExtensionStoreRepository> { AnimeExtensionStoreRepositoryImpl(get(), get()) }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/MangaExtensionReposScreenModel.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/MangaExtensionReposScreenModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import dev.icerock.moko.resources.StringResource
+import eu.kanade.tachiyomi.extension.manga.MangaExtensionManager
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.channels.Channel
@@ -27,6 +28,7 @@ class MangaExtensionReposScreenModel(
     private val deleteExtensionRepo: DeleteMangaExtensionRepo = Injekt.get(),
     private val replaceExtensionRepo: ReplaceMangaExtensionRepo = Injekt.get(),
     private val updateExtensionRepo: UpdateMangaExtensionRepo = Injekt.get(),
+    private val extensionManager: MangaExtensionManager = Injekt.get(),
 ) : StateScreenModel<RepoScreenState>(RepoScreenState.Loading) {
 
     private val _events: Channel<RepoEvent> = Channel(Int.MAX_VALUE)
@@ -58,6 +60,7 @@ class MangaExtensionReposScreenModel(
                 is CreateMangaExtensionRepo.Result.DuplicateFingerprint -> {
                     showDialog(RepoDialog.Conflict(result.oldRepo, result.newRepo))
                 }
+                CreateMangaExtensionRepo.Result.Success -> extensionManager.findAvailableExtensions()
                 else -> {}
             }
         }
@@ -93,6 +96,7 @@ class MangaExtensionReposScreenModel(
     fun deleteRepo(baseUrl: String) {
         screenModelScope.launchIO {
             deleteExtensionRepo.await(baseUrl)
+            extensionManager.findAvailableExtensions()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/MangaExtensionManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/MangaExtensionManager.kt
@@ -236,7 +236,7 @@ class MangaExtensionManager(
      * @param extension The extension to be installed.
      */
     fun installExtension(extension: MangaExtension.Available): Flow<InstallStep> {
-        return installer.downloadAndInstall(api.getApkUrl(extension), extension)
+        return installer.downloadAndInstall(extension.apkUrl, extension)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/api/MangaExtensionApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/api/MangaExtensionApi.kt
@@ -9,15 +9,22 @@ import eu.kanade.tachiyomi.extension.manga.util.MangaExtensionLoader
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.awaitSuccess
-import eu.kanade.tachiyomi.network.parseAs
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.okio.decodeFromBufferedSource
+import kotlinx.serialization.protobuf.ProtoBuf
 import logcat.LogPriority
 import mihon.domain.extensionrepo.manga.interactor.GetMangaExtensionRepo
 import mihon.domain.extensionrepo.manga.interactor.UpdateMangaExtensionRepo
 import mihon.domain.extensionrepo.model.ExtensionRepo
+import mihon.domain.extensionrepo.model.NetworkMangaExtensionStore
+import mihon.domain.extensionrepo.service.ExtensionRepoService
+import okio.BufferedSource
+import okio.buffer
+import okio.gzip
 import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.util.lang.withIOContext
@@ -32,8 +39,10 @@ internal class MangaExtensionApi {
     private val preferenceStore: PreferenceStore by injectLazy()
     private val getExtensionRepo: GetMangaExtensionRepo by injectLazy()
     private val updateExtensionRepo: UpdateMangaExtensionRepo by injectLazy()
+    private val extensionRepoService: ExtensionRepoService by injectLazy()
     private val extensionManager: MangaExtensionManager by injectLazy()
     private val json: Json by injectLazy()
+    private val protoBuf: ProtoBuf by injectLazy()
 
     private val lastExtCheck: Preference<Long> by lazy {
         preferenceStore.getLong("last_ext_check", 0)
@@ -51,19 +60,66 @@ internal class MangaExtensionApi {
     private suspend fun getExtensions(extRepo: ExtensionRepo): List<MangaExtension.Available> {
         val repoBaseUrl = extRepo.baseUrl
         return try {
-            val response = networkService.client
-                .newCall(GET("$repoBaseUrl/index.min.json"))
-                .awaitSuccess()
-
-            with(json) {
-                response
-                    .parseAs<List<ExtensionJsonObject>>()
-                    .toExtensions(repoBaseUrl)
-            }
+            fetchExtensionList(resolveIndexUrl(repoBaseUrl))
+                .filter { it.libVersion in MangaExtensionLoader.SUPPORTED_LIB_VERSIONS }
         } catch (e: Throwable) {
             logcat(LogPriority.ERROR, e) { "Failed to get extensions from $repoBaseUrl" }
             emptyList()
         }
+    }
+
+    /**
+     * A repo's stored url is either a direct link to its extension list ("index.min.json" or
+     * "index.pb"), or, for repos added before this existed, a bare base url. Bare urls, and
+     * urls still pointing at "index.min.json", are re-checked against "repo.json"'s
+     * "index_v2" on every call, so a repo that migrates to the newer format after being
+     * added keeps working without the user having to remove and re-add it. A "index.pb" url
+     * is already the final, self-describing format and needs no such check.
+     */
+    private suspend fun resolveIndexUrl(repoBaseUrl: String): String {
+        if (repoBaseUrl.endsWith(".pb")) return repoBaseUrl
+
+        val repoDir = if (repoBaseUrl.endsWith(".json")) repoBaseUrl.substringBeforeLast('/') else repoBaseUrl
+        val indexV2 = extensionRepoService.fetchIndexUrl(repoDir)
+        if (indexV2 != null) return indexV2
+
+        return if (repoBaseUrl.endsWith(".json")) repoBaseUrl else "$repoBaseUrl/index.min.json"
+    }
+
+    /**
+     * Repos publish extensions either as a plain JSON array at "index.min.json" (the legacy
+     * format), or, once migrated to Mihon's newer format, as a JSON object or gzip-compressed
+     * protobuf message ("index.pb").
+     */
+    private suspend fun fetchExtensionList(indexUrl: String): List<MangaExtension.Available> {
+        val response = networkService.client.newCall(GET(indexUrl)).awaitSuccess()
+        val repoDir = indexUrl.substringBeforeLast('/')
+        return response.body.source().decompressIfGzipped().use { source ->
+            when (source.peek().readByte()) {
+                // "[..."
+                0x5B.toByte() -> json.decodeFromBufferedSource<List<ExtensionJsonObject>>(source)
+                    .toExtensions(repoDir)
+                // "{..."
+                0x7B.toByte() -> json.decodeFromBufferedSource<NetworkMangaExtensionStore>(source)
+                    .extensionList!!
+                    .toExtensions(repoDir)
+                else -> protoBuf.decodeFromByteArray<NetworkMangaExtensionStore>(source.readByteArray())
+                    .extensionList!!
+                    .toExtensions(repoDir)
+            }
+        }
+    }
+
+    private fun BufferedSource.decompressIfGzipped(): BufferedSource {
+        val isGzip = peek().use { peeked ->
+            try {
+                peeked.readShort().toInt() == 0x1f8b
+            } catch (_: Exception) {
+                false
+            }
+        }
+
+        return if (isGzip) gzip().buffer() else this
     }
 
     suspend fun checkForUpdates(
@@ -110,34 +166,47 @@ internal class MangaExtensionApi {
     }
 
     private fun List<ExtensionJsonObject>.toExtensions(repoUrl: String): List<MangaExtension.Available> {
-        return this
-            .filter {
-                val libVersion = it.extractLibVersion()
-                libVersion >= MangaExtensionLoader.LIB_VERSION_MIN && libVersion <= MangaExtensionLoader.LIB_VERSION_MAX
-            }
-            .map {
-                MangaExtension.Available(
-                    name = it.name.substringAfter("Tachiyomi: "),
-                    pkgName = it.pkg,
-                    versionName = it.version,
-                    versionCode = it.code,
-                    libVersion = it.extractLibVersion(),
-                    lang = it.lang,
-                    isNsfw = it.nsfw == 1,
-                    sources = it.sources?.map(extensionSourceMapper).orEmpty(),
-                    apkName = it.apk,
-                    iconUrl = "$repoUrl/icon/${it.pkg}.png",
-                    repoUrl = repoUrl,
-                )
-            }
+        return this.map {
+            MangaExtension.Available(
+                name = it.name.substringAfter("Tachiyomi: "),
+                pkgName = it.pkg,
+                versionName = it.version,
+                versionCode = it.code,
+                libVersion = it.version.substringBeforeLast('.').toDouble(),
+                lang = it.lang,
+                isNsfw = it.nsfw == 1,
+                sources = it.sources?.map(extensionSourceMapper).orEmpty(),
+                apkUrl = "$repoUrl/apk/${it.apk}",
+                iconUrl = "$repoUrl/icon/${it.pkg}.png",
+                repoUrl = repoUrl,
+            )
+        }
     }
 
-    fun getApkUrl(extension: MangaExtension.Available): String {
-        return "${extension.repoUrl}/apk/${extension.apkName}"
-    }
-
-    private fun ExtensionJsonObject.extractLibVersion(): Double {
-        return version.substringBeforeLast('.').toDouble()
+    private fun NetworkMangaExtensionStore.ExtensionList.toExtensions(repoUrl: String): List<MangaExtension.Available> {
+        return extensions.map { extension ->
+            val lang = extension.sources.map { it.language }.toSet()
+            MangaExtension.Available(
+                name = extension.name,
+                pkgName = extension.packageName,
+                versionName = extension.versionName,
+                versionCode = extension.versionCode,
+                libVersion = extension.extensionLib.toDouble(),
+                lang = if (lang.size == 1) lang.first() else "all",
+                isNsfw = extension.contentWarning >= NetworkMangaExtensionStore.ContentWarning.MIXED,
+                sources = extension.sources.map { source ->
+                    MangaExtension.Available.MangaSource(
+                        id = source.id,
+                        lang = source.language,
+                        name = source.name,
+                        baseUrl = source.homeUrl,
+                    )
+                },
+                apkUrl = extension.resources.apkUrl,
+                iconUrl = extension.resources.iconUrl,
+                repoUrl = repoUrl,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/model/MangaExtension.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/model/MangaExtension.kt
@@ -40,7 +40,7 @@ sealed class MangaExtension {
         override val lang: String,
         override val isNsfw: Boolean,
         val sources: List<MangaSource>,
-        val apkName: String,
+        val apkUrl: String,
         val iconUrl: String,
         val repoUrl: String,
     ) : MangaExtension() {

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoader.kt
@@ -53,8 +53,7 @@ internal object MangaExtensionLoader {
     private const val METADATA_SOURCE_CLASS = "tachiyomi.extension.class"
     private const val METADATA_SOURCE_FACTORY = "tachiyomi.extension.factory"
     private const val METADATA_NSFW = "tachiyomi.extension.nsfw"
-    const val LIB_VERSION_MIN = 1.4
-    const val LIB_VERSION_MAX = 1.5
+    val SUPPORTED_LIB_VERSIONS = listOf(1.4, 1.6)
 
     @Suppress("DEPRECATION")
     private val PACKAGE_FLAGS = PackageManager.GET_CONFIGURATIONS or
@@ -262,10 +261,9 @@ internal object MangaExtensionLoader {
 
         // Validate lib version
         val libVersion = versionName.substringBeforeLast('.').toDoubleOrNull()
-        if (libVersion == null || libVersion < LIB_VERSION_MIN || libVersion > LIB_VERSION_MAX) {
+        if (libVersion == null || libVersion !in SUPPORTED_LIB_VERSIONS) {
             logcat(LogPriority.WARN) {
-                "Lib version is $libVersion, while only versions " +
-                    "$LIB_VERSION_MIN to $LIB_VERSION_MAX are allowed"
+                "Lib version is $libVersion, while only version(s) ${SUPPORTED_LIB_VERSIONS.joinToString()} are supported"
             }
             return MangaLoadResult.Error
         }

--- a/domain/src/main/java/mihon/domain/extensionrepo/manga/interactor/CreateMangaExtensionRepo.kt
+++ b/domain/src/main/java/mihon/domain/extensionrepo/manga/interactor/CreateMangaExtensionRepo.kt
@@ -12,16 +12,15 @@ class CreateMangaExtensionRepo(
     private val repository: MangaExtensionRepoRepository,
     private val service: ExtensionRepoService,
 ) {
-    private val repoRegex = """^https://.*/index\.min\.json$""".toRegex()
-
     suspend fun await(indexUrl: String): Result {
-        val formattedIndexUrl = indexUrl.toHttpUrlOrNull()
+        // accept index.json or index.pb
+        val entryUrl = indexUrl.toHttpUrlOrNull()
+            ?.takeIf { it.scheme == "https" }
             ?.toString()
-            ?.takeIf { it.matches(repoRegex) }
+            ?.takeIf { it.endsWith(".json") || it.endsWith(".pb") }
             ?: return Result.InvalidUrl
 
-        val baseUrl = formattedIndexUrl.removeSuffix("/index.min.json")
-        return service.fetchRepoDetails(baseUrl)?.let { insert(it) } ?: Result.InvalidUrl
+        return service.fetchRepoDetails(entryUrl)?.let { insert(it) } ?: Result.InvalidUrl
     }
 
     private suspend fun insert(repo: ExtensionRepo): Result {

--- a/domain/src/main/java/mihon/domain/extensionrepo/model/NetworkMangaExtensionStore.kt
+++ b/domain/src/main/java/mihon/domain/extensionrepo/model/NetworkMangaExtensionStore.kt
@@ -1,0 +1,88 @@
+package mihon.domain.extensionrepo.model
+
+import android.annotation.SuppressLint
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
+import kotlinx.serialization.protobuf.ProtoNumber
+
+/**
+ * basically a copy of Mihon's NetworkExtensionStore.kt
+ * https://github.com/mihonapp/mihon/blob/main/data/src/main/java/mihon/data/extension/model/NetworkExtensionStore.kt
+ * protobuf definition file
+ */
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
+data class NetworkMangaExtensionStore(
+    @ProtoNumber(1) val name: String,
+    @ProtoNumber(2) val badgeLabel: String,
+    @ProtoNumber(3) val signingKey: String,
+    @ProtoNumber(4) val contact: Contact,
+    @ProtoNumber(101) val extensionList: ExtensionList?,
+    @ProtoNumber(102) val extensionListUrl: String?,
+) {
+    @Serializable
+    data class Contact(
+        @ProtoNumber(1) val website: String,
+        @ProtoNumber(2) val discord: String?,
+    )
+
+    @Serializable
+    data class ExtensionList(@ProtoNumber(1) val extensions: List<Extension>)
+
+    @Serializable
+    data class Extension(
+        @ProtoNumber(1) val name: String,
+        @ProtoNumber(2) val packageName: String,
+        @ProtoNumber(3) val resources: Resources,
+        @ProtoNumber(4) val extensionLib: String,
+        @ProtoNumber(5) val versionCode: Long,
+        @ProtoNumber(6) val versionName: String,
+        @ProtoNumber(7) val contentWarning: ContentWarning,
+        @ProtoNumber(8) val sources: List<Source>,
+    )
+
+    @Serializable
+    data class Resources(
+        @ProtoNumber(1) val apkUrl: String,
+        @ProtoNumber(2) val iconUrl: String,
+    )
+
+    @Serializable
+    data class Source(
+        @ProtoNumber(1) val id: Long,
+        @ProtoNumber(2) val name: String,
+        @ProtoNumber(3) val language: String,
+        @ProtoNumber(4) val homeUrl: String = "",
+        @ProtoNumber(5) val mirrorUrls: List<String> = emptyList(),
+        @ProtoNumber(7) val message: String? = null,
+    )
+
+    @Suppress("Unused")
+    enum class ContentWarning {
+        @ProtoNumber(0)
+        @JsonNames("CONTENT_WARNING_UNSPECIFIED")
+        UNSPECIFIED,
+
+        @ProtoNumber(1)
+        @JsonNames("CONTENT_WARNING_SAFE")
+        SAFE,
+
+        @ProtoNumber(2)
+        @JsonNames("CONTENT_WARNING_MIXED")
+        MIXED,
+
+        @ProtoNumber(3)
+        @JsonNames("CONTENT_WARNING_NSFW")
+        NSFW,
+    }
+
+    fun toExtensionRepo(baseUrl: String): ExtensionRepo {
+        return ExtensionRepo(
+            baseUrl = baseUrl,
+            name = name,
+            shortName = badgeLabel,
+            website = contact.website,
+            signingKeyFingerprint = signingKey,
+        )
+    }
+}

--- a/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoDto.kt
+++ b/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoDto.kt
@@ -1,10 +1,13 @@
 package mihon.domain.extensionrepo.service
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import mihon.domain.extensionrepo.model.ExtensionRepo
 
 @Serializable
 data class ExtensionRepoMetaDto(
+    @SerialName("index_v2")
+    val indexV2: String? = null,
     val meta: ExtensionRepoDto,
 )
 

--- a/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoService.kt
+++ b/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoService.kt
@@ -4,33 +4,108 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.parseAs
+import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.okio.decodeFromBufferedSource
+import kotlinx.serialization.protobuf.ProtoBuf
 import logcat.LogPriority
 import mihon.domain.extensionrepo.model.ExtensionRepo
+import mihon.domain.extensionrepo.model.NetworkMangaExtensionStore
+import okio.BufferedSource
+import okio.buffer
+import okio.gzip
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 
 class ExtensionRepoService(
     networkHelper: NetworkHelper,
     private val json: Json,
+    private val protoBuf: ProtoBuf,
 ) {
     val client = networkHelper.client
 
+    /**
+     * Fetches repo metadata from repo.json or gzip-compressed protobuf file
+     * that carries its metadata inline.
+     */
     suspend fun fetchRepoDetails(
-        repo: String,
+        indexUrl: String,
     ): ExtensionRepo? {
+        return withIOContext {
+            try {
+                digest(indexUrl)
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Failed to fetch repo details" }
+                null
+            }
+        }
+    }
+
+    private suspend fun digest(indexUrl: String): ExtensionRepo {
+        val response = client.newCall(GET(indexUrl)).awaitSuccess()
+        return response.body.source().decompressIfGzipped().use { source ->
+            when (source.peek().readByte()) {
+                // metadata lives in a sibling repo.json
+                0x5B.toByte() -> {
+                    val repoJsonUrl = "${indexUrl.substringBeforeLast('/')}/repo.json"
+                    val meta = with(json) {
+                        client.newCall(GET(repoJsonUrl)).awaitSuccess().parseAs<ExtensionRepoMetaDto>()
+                    }
+                    meta.indexV2?.let { return digest(it) }
+                    meta.toExtensionRepo(baseUrl = indexUrl)
+                }
+                // legacy repo.json shape or the new JSON form
+                0x7B.toByte() -> {
+                    val meta = try {
+                        json.decodeFromBufferedSource<ExtensionRepoMetaDto>(source.peek())
+                    } catch (_: Exception) {
+                        null
+                    }
+                    when {
+                        meta?.indexV2 != null -> return digest(meta.indexV2)
+                        meta != null -> meta.toExtensionRepo(baseUrl = indexUrl)
+                        else -> json.decodeFromBufferedSource<NetworkMangaExtensionStore>(source)
+                            .toExtensionRepo(baseUrl = indexUrl)
+                    }
+                }
+                // gzip-compressed protobuf
+                else -> protoBuf.decodeFromByteArray<NetworkMangaExtensionStore>(source.readByteArray())
+                    .toExtensionRepo(baseUrl = indexUrl)
+            }
+        }
+    }
+
+    /**
+     * Repos migrated to protobuf format point via index_v2 in repo.json
+     * Returns null for repos that haven't migrated or DNE
+     */
+    suspend fun fetchIndexUrl(
+        repo: String,
+    ): String? {
         return withIOContext {
             try {
                 with(json) {
                     client.newCall(GET("$repo/repo.json"))
                         .awaitSuccess()
                         .parseAs<ExtensionRepoMetaDto>()
-                        .toExtensionRepo(baseUrl = repo)
+                        .indexV2
                 }
             } catch (e: Exception) {
-                logcat(LogPriority.ERROR, e) { "Failed to fetch repo details" }
+                logcat(LogPriority.ERROR, e) { "Failed to fetch repo index url" }
                 null
             }
         }
+    }
+
+    private fun BufferedSource.decompressIfGzipped(): BufferedSource {
+        val isGzip = peek().use { peeked ->
+            try {
+                peeked.readShort().toInt() == 0x1f8b
+            } catch (_: Exception) {
+                false
+            }
+        }
+
+        return if (isGzip) gzip().buffer() else this
     }
 }


### PR DESCRIPTION
New extension type `index.pb` is a gzip-compressed protobuf file. Adding support to index this new file type for manga. Mostly based on mihon implementation. Should not affect existing .json parsing.


https://github.com/user-attachments/assets/86309572-6b97-47b9-91c0-2b90a080e50a

I did replace the regex to `endsWith` string. Not sure if there were specific reasons why regex was used.